### PR TITLE
Deep copy options when creating a connection

### DIFF
--- a/NATS/Conn.cs
+++ b/NATS/Conn.cs
@@ -453,7 +453,7 @@ namespace NATS.Client
 
         internal Connection(Options opts)
         {
-            this.opts = opts;
+            this.opts = new Options(opts);
             this.pongs = createPongs();
             this.ps = new Parser(this);
 

--- a/NATS/Options.cs
+++ b/NATS/Options.cs
@@ -55,8 +55,52 @@ namespace NATS.Client
 
         internal int subChanLen = 40000;
 
-        // Options can only be created through ConnectionFactory.GetDefaultOptions();
+        // Options can only be publicly created through 
+        // ConnectionFactory.GetDefaultOptions();
         internal Options() { }
+
+        // Copy constructor
+        internal Options(Options o)
+        {
+            this.allowReconnect = o.allowReconnect;
+            this.AsyncErrorEventHandler = o.AsyncErrorEventHandler;
+            this.ClosedEventHandler = o.ClosedEventHandler;
+            this.DisconnectedEventHandler = o.DisconnectedEventHandler;
+            this.maxPingsOut = o.maxPingsOut;
+            this.maxReconnect = o.maxReconnect;
+
+            if (o.name != null)
+            {
+                this.name = new string(o.name.ToCharArray());
+            }
+
+            this.noRandomize = o.noRandomize;
+            this.pedantic = o.pedantic;
+            this.pingInterval = o.pingInterval;
+            this.ReconnectedEventHandler = o.ReconnectedEventHandler;
+            this.reconnectWait = o.reconnectWait;
+            this.secure = o.secure;
+            
+            if (o.servers != null)
+            {
+                this.servers = new string[o.servers.Length];
+                Array.Copy(o.servers, this.servers, o.servers.Length);
+            }
+
+            this.subChanLen = o.subChanLen;
+            this.timeout = o.timeout;
+            this.TLSRemoteCertificationValidationCallback = o.TLSRemoteCertificationValidationCallback;
+
+            if (o.url != null)
+            {
+                this.url = new String(o.url.ToCharArray());
+            }
+
+            if (o.certificates != null)
+            {
+                this.certificates = new X509Certificate2Collection(o.certificates);
+            }
+        }
 
         /// <summary>
         /// Gets or sets the url used to connect to the NATs server.  This may

--- a/NATSUnitTests/UnitTestSub.cs
+++ b/NATSUnitTests/UnitTestSub.cs
@@ -268,7 +268,7 @@ namespace NATSUnitTests
             {
                 using (s = c.SubscribeAsync("foo"))
                 {
-                    opts.AsyncErrorEventHandler = (sender, args) =>
+                    c.Opts.AsyncErrorEventHandler = (sender, args) =>
                     {
                         lock (subLock)
                         {
@@ -299,7 +299,7 @@ namespace NATSUnitTests
                                 return;
 
                             Console.WriteLine("Subscriber Waiting....");
-                            Assert.IsTrue(Monitor.Wait(subLock, 10000));
+                            Assert.IsTrue(Monitor.Wait(subLock, 500));
                             Console.WriteLine("Subscriber done.");
                             blockedOnSubscriber = true;
                         }
@@ -314,7 +314,7 @@ namespace NATSUnitTests
                         {
                             c.Publish("foo", null);
                         }
-
+ 
                         try
                         {
                             c.Flush(1000);

--- a/NATSUnitTests/UnitTestUtilities.cs
+++ b/NATSUnitTests/UnitTestUtilities.cs
@@ -194,10 +194,16 @@ namespace NATSUnitTests
 
         internal static void CleanupExistingServers()
         {
-            Process[] procs = Process.GetProcessesByName("gnatsd");
+            try
+            {
+                Process[] procs = Process.GetProcessesByName("gnatsd");
 
-            foreach (Process proc in procs)
-                proc.Kill();
+                foreach (Process proc in procs)
+                {
+                    proc.Kill();
+                }
+            }
+            catch (Exception) { } // ignore
         }
     }
 }


### PR DESCRIPTION
Modifying options could affect a live connection.  Make a deep copy when creating the connection to prevent this.  Updated some unit tests.
