### PR TITLE
sendConnect() does not handle +OK when Verbose option is set

### DIFF
--- a/NATS/Conn.cs
+++ b/NATS/Conn.cs
@@ -946,6 +946,13 @@ namespace NATS.Client
                 StreamReader sr = new StreamReader(br);
                 result = sr.ReadLine();
 
+
+                // If opts.verbose is set, handle +OK.
+                if (opts.Verbose == true && IC.okProtoNoCRLF.Equals(result))
+                {
+                    result = sr.ReadLine();
+                }
+
                 // Do not close or dispose the stream reader; 
                 // we need the underlying BufferedStream.
             }

--- a/NATS/NATS.cs
+++ b/NATS/NATS.cs
@@ -226,6 +226,7 @@ namespace NATS.Client
         internal const string unsubProto = "UNSUB {0} {1}" + IC._CRLF_;
 
         internal const string pongProtoNoCRLF = "PONG";
+        internal const string okProtoNoCRLF = "+OK";
 
         internal const string STALE_CONNECTION = "Stale Connection";
     }

--- a/NATS/Options.cs
+++ b/NATS/Options.cs
@@ -80,6 +80,7 @@ namespace NATS.Client
             this.ReconnectedEventHandler = o.ReconnectedEventHandler;
             this.reconnectWait = o.reconnectWait;
             this.secure = o.secure;
+            this.verbose = o.verbose;
             
             if (o.servers != null)
             {

--- a/NATSUnitTests/NATSUnitTests.csproj
+++ b/NATSUnitTests/NATSUnitTests.csproj
@@ -22,7 +22,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>c:\tmp\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -171,6 +171,17 @@ namespace NATSUnitTests
                 typeof(NATSConnectionClosedException));
         }
 
+        [TestMethod]
+        public void TestConnectVerbose()
+        {
+
+            Options o = ConnectionFactory.GetDefaultOptions();
+            o.Verbose = true;
+
+            IConnection c = new ConnectionFactory().CreateConnection(o);
+            c.Close();
+        }
+        
         /// NOT IMPLEMENTED:
         /// TestServerSecureConnections
         /// TestErrOnConnectAndDeadlock


### PR DESCRIPTION
- Fixed verbose issue when setting options
- Added Tests
- Removed old commented test code.

See:  https://github.com/nats-io/csnats/issues/21
