### PR TITLE
Delay the flusher to boost publishing performance.

### DIFF
--- a/NATS/Conn.cs
+++ b/NATS/Conn.cs
@@ -1506,6 +1506,10 @@ namespace NATS.Client
                 if (val == false)
                     return;
 
+                // Yield for a microsecond.  This reduces resource contention,
+                // increasing throughput by about 50%.
+                Thread.Sleep(1);
+
                 lock (mu)
                 {
                     if (!isConnected())


### PR DESCRIPTION
Adding a slight delay in the flusher reduces resource contention, allowing higher throughput rates when publishing.  4.7 M msgs/sec on a VM.
