### PR TITLE
Fix json parsing to allow for a ':' in values.

### DIFF
--- a/NATS/Conn.cs
+++ b/NATS/Conn.cs
@@ -69,7 +69,7 @@ namespace NATS.Client
 
             kv_pair.Trim();
 
-            string[] parts = kv_pair.Split(':');
+            string[] parts = kv_pair.Split(new string[] {"\":"}, StringSplitOptions.None);
 
             // silently ignore what we don't understand.
             if (parts.Length != 2)


### PR DESCRIPTION
This fixes an issue that arises when connecting to the NATS server version 0.7.9, which has a : in the server_id field.
