### PR TITLE
Ignore I/O exceptions where not applicable.

### DIFF
--- a/NATS/Conn.cs
+++ b/NATS/Conn.cs
@@ -1611,7 +1611,13 @@ namespace NATS.Client
                         return;
 
                     if (bw.CanWrite)
-                        bw.Flush();
+                    {
+                        try
+                        {
+                            bw.Flush();
+                        }
+                        catch (Exception) {  /* ignore */ }
+                    }
                 }
             }
         }
@@ -2201,7 +2207,13 @@ namespace NATS.Client
                 if (conn.isSetup())
                 {
                     if (bw != null)
-                        bw.Flush();
+                    {
+                        try
+                        {
+                            bw.Flush();
+                        }
+                        catch (Exception) { /* ignore */ }
+                    }
 
                     conn.teardown();
                 }


### PR DESCRIPTION
While code accounts for connection state, in rare cases, the underlying socket state can change and cause I/O exceptions accessing the buffered writer during the reconnect process.  Ignore these exceptions to allow higher level reconnect code to reestablish the connection or error out.

No automated test as behavior is undefined/unpredictable when this occurs.
