### PR TITLE
Exception in clearPendingFlushCalls()

### DIFF
--- a/NATS/Conn.cs
+++ b/NATS/Conn.cs
@@ -2200,14 +2200,12 @@ namespace NATS.Client
         // Lock must be held by the caller.
         private void clearPendingFlushCalls()
         {
-            lock (mu)
+
+            // Clear any queued pongs, e.g. pending flush calls.
+            foreach (Channel<bool> ch in pongs)
             {
-                // Clear any queued pongs, e.g. pending flush calls.
-                foreach (Channel<bool> ch in pongs)
-                {
-                    if (ch != null)
-                        ch.add(true);
-                }
+                if (ch != null)
+                    ch.add(true);
             }
             pongs.Clear();
         }
@@ -2234,11 +2232,11 @@ namespace NATS.Client
             // fch will be closed on finalizer
             kickFlusher();
 
-            // Clear any queued pongs, e.g. pending flush calls.
-            clearPendingFlushCalls();
-
             lock (mu)
             {
+                // Clear any queued pongs, e.g. pending flush calls.
+                clearPendingFlushCalls();
+
                 stopPingTimer();
 
                 // Close sync subscriber channels and release any

--- a/NATS/Conn.cs
+++ b/NATS/Conn.cs
@@ -2200,13 +2200,15 @@ namespace NATS.Client
         // Lock must be held by the caller.
         private void clearPendingFlushCalls()
         {
-            // Clear any queued pongs, e.g. pending flush calls.
-            foreach (Channel<bool> ch in pongs)
+            lock (mu)
             {
-                if (ch != null)
-                    ch.add(true);
+                // Clear any queued pongs, e.g. pending flush calls.
+                foreach (Channel<bool> ch in pongs)
+                {
+                    if (ch != null)
+                        ch.add(true);
+                }
             }
-
             pongs.Clear();
         }
 


### PR DESCRIPTION
Test 'NATSUnitTests.TestReconnect.TestIsReconnectingAndStatus' failed: Test method NATSUnitTests.TestReconnect.TestIsReconnectingAndStatus threw exception: 
System.InvalidOperationException: Collection was modified after the enumerator was instantiated.
at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
at System.Collections.Generic.Queue`1.Enumerator.MoveNext()
Conn.cs(2190,0): at NATS.Client.Connection.clearPendingFlushCalls()
Conn.cs(2222,0): at NATS.Client.Connection.close(ConnState closeState, Boolean invokeDelegates)
Conn.cs(2271,0): at NATS.Client.Connection.Close()
UnitTestReconnect.cs(488,0): at NATSUnitTests.TestReconnect.TestIsReconnectingAndStatus()

7 passed, 1 failed, 0 skipped, took 17,00 seconds (MSTest 10.0).
