### PR TITLE
Test authorization timeout errors in reconnect

### DIFF
--- a/NATSUnitTests/NATSUnitTests.csproj
+++ b/NATSUnitTests/NATSUnitTests.csproj
@@ -80,8 +80,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="config\auth_1223_timeout.conf" />
     <None Include="config\auth_1224.conf" />
     <None Include="config\auth_1222.conf" />
+    <None Include="config\auth_tls_1222.conf" />
+    <None Include="config\auth_tls_1223_timeout.conf" />
+    <None Include="config\auth_tls_1224.conf" />
     <None Include="config\tls_1224.conf" />
     <None Include="config\tls_1222.conf" />
     <None Include="config\tls_1222_user.conf" />

--- a/NATSUnitTests/config/auth_1223_timeout.conf
+++ b/NATSUnitTests/config/auth_1223_timeout.conf
@@ -1,0 +1,8 @@
+port: 1223 # port to listen for client connections
+
+# Authorization for client connections
+authorization {
+  user:     username
+  password: password
+  timeout:  0.001
+}

--- a/NATSUnitTests/config/auth_tls_1222.conf
+++ b/NATSUnitTests/config/auth_tls_1222.conf
@@ -1,0 +1,31 @@
+port: 1222 # port to listen for client connections
+
+# Authorization for client connections
+authorization {
+  user:     username
+  password: password
+  timeout:  1
+}
+
+tls {
+  # Server cert
+  cert_file: "./certs/server-cert.pem"
+  # Server private key
+  key_file:  "./certs/server-key.pem"
+
+  cipher_suites: [
+	"TLS_RSA_WITH_RC4_128_SHA",
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+	"TLS_RSA_WITH_AES_128_CBC_SHA",
+	"TLS_RSA_WITH_AES_256_CBC_SHA",
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+  ]
+}

--- a/NATSUnitTests/config/auth_tls_1223_timeout.conf
+++ b/NATSUnitTests/config/auth_tls_1223_timeout.conf
@@ -1,0 +1,31 @@
+port: 1223 # port to listen for client connections
+
+# Authorization for client connections
+authorization {
+  user:     username
+  password: password
+  timeout:  0.001
+}
+
+tls {
+  # Server cert
+  cert_file: "./certs/server-cert.pem"
+  # Server private key
+  key_file:  "./certs/server-key.pem"
+
+  cipher_suites: [
+	"TLS_RSA_WITH_RC4_128_SHA",
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+	"TLS_RSA_WITH_AES_128_CBC_SHA",
+	"TLS_RSA_WITH_AES_256_CBC_SHA",
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+  ]
+}

--- a/NATSUnitTests/config/auth_tls_1224.conf
+++ b/NATSUnitTests/config/auth_tls_1224.conf
@@ -1,0 +1,31 @@
+port: 1224 # port to listen for client connections
+
+# Authorization for client connections
+authorization {
+  user:     username
+  password: password
+  timeout:  1
+}
+
+tls {
+  # Server cert
+  cert_file: "./certs/server-cert.pem"
+  # Server private key
+  key_file:  "./certs/server-key.pem"
+
+  cipher_suites: [
+	"TLS_RSA_WITH_RC4_128_SHA",
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+	"TLS_RSA_WITH_AES_128_CBC_SHA",
+	"TLS_RSA_WITH_AES_256_CBC_SHA",
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+  ]
+}


### PR DESCRIPTION
Add tests to check that an authorization timeout error will not cause failures during reconnect with TLS Enabled and non-secure servers.
