### PR TITLE
Allow future reconnect attempts after an authorization timeout error

### DIFF
--- a/NATS/Conn.cs
+++ b/NATS/Conn.cs
@@ -1752,6 +1752,13 @@ namespace NATS.Client
             {
                 processOpError(new NATSStaleConnectionException());
             }
+            else if (IC.AUTH_TIMEOUT.Equals(s))
+            {
+                // Protect against a timing issue where an authoriztion error
+                // is handled before the connection close from the server.
+                // This can happen in reconnect scenarios.
+                processOpError(new NATSConnectionException(IC.AUTH_TIMEOUT));
+            }
             else
             {
                 ex = new NATSException(s);

--- a/NATS/NATS.cs
+++ b/NATS/NATS.cs
@@ -239,6 +239,7 @@ namespace NATS.Client
         internal const string okProtoNoCRLF = "+OK";
 
         internal const string STALE_CONNECTION = "Stale Connection";
+        internal const string AUTH_TIMEOUT = "Authorization Timeout";
     }
 
     /// <summary>


### PR DESCRIPTION
In some situations, the timing may be such that a client fully processes a server authorization timeout before the server closes the connection.  Handle that case to allow the client to attempt reconnection.
