### PR TITLE
Fix connection closed on authorization timeout

### DIFF
--- a/NATS/NATS.cs
+++ b/NATS/NATS.cs
@@ -238,8 +238,8 @@ namespace NATS.Client
         internal const string pongProtoNoCRLF = "PONG";
         internal const string okProtoNoCRLF = "+OK";
 
-        internal const string STALE_CONNECTION = "Stale Connection";
-        internal const string AUTH_TIMEOUT = "Authorization Timeout";
+        internal const string STALE_CONNECTION = "stale connection";
+        internal const string AUTH_TIMEOUT = "authorization timeout";
     }
 
     /// <summary>

--- a/NATS/Parser.cs
+++ b/NATS/Parser.cs
@@ -319,6 +319,7 @@ namespace NATS.Client
                                 break;
                             default:
                                 state = MINUS_ERR_ARG;
+                                i--;
                                 break;
                         }
                         break;

--- a/NATSUnitTests/NATSUnitTests.csproj
+++ b/NATSUnitTests/NATSUnitTests.csproj
@@ -22,7 +22,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>c:\tmp\bin\Debug\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/NATSUnitTests/UnitTestAuth.cs
+++ b/NATSUnitTests/UnitTestAuth.cs
@@ -6,6 +6,7 @@ using NATS.Client;
 using System.Threading;
 using System.Reflection;
 using System.IO;
+using System.Linq;
 
 namespace NATSUnitTests
 {
@@ -184,19 +185,19 @@ namespace NATSUnitTests
 
                 IConnection c = new ConnectionFactory().CreateConnection(opts);
 
-                // inject an authorization timeout, as if it were processed by an incoming 
-                // server message.
-                using (MemoryStream ms = new MemoryStream())
-                {
-                    byte[] value = System.Text.Encoding.UTF8.GetBytes("Authorization Timeout");
-                    ms.Write(value, 0, value.Length);
+                // inject an authorization timeout, as if it were processed by an incoming server message.
+                // this is done at the parser level so that parsing is also tested,
+                // therefore it needs reflection since Parser is an internal type.
+                Type parserType = typeof(Connection).Assembly.GetType("NATS.Client.Parser");
+                Assert.IsNotNull(parserType, "Failed to find NATS.Client.Parser");
+                BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
+                object parser = Activator.CreateInstance(parserType, flags, null, new object[] { c }, null);
+                Assert.IsNotNull(parser, "Failed to instanciate a NATS.Client.Parser");
+                MethodInfo parseMethod = parserType.GetMethod("parse", flags);
+                Assert.IsNotNull(parseMethod, "Failed to find method parse in NATS.Client.Parser");
 
-                    MethodInfo processErr = typeof(Connection).GetMethod(
-                        "processErr",
-                        BindingFlags.NonPublic | BindingFlags.Instance);
-
-                    processErr.Invoke(c, new object[] { ms });
-                }
+                byte[] bytes = "-ERR 'Authorization Timeout'\r\n".ToCharArray().Select(ch => (byte)ch).ToArray();
+                parseMethod.Invoke(parser, new object[] { bytes, bytes.Length });
 
                 // sleep to allow the client to process the error, then shutdown the server.
                 Thread.Sleep(250);


### PR DESCRIPTION
This is an alternative to #68.

Also note that it would also make sense for the other nats client to have the same behavior (disconnect on authorization timeout, not close).
