### PR TITLE
Saves exception context on rethrow in processExpectedInfo

### DIFF
--- a/NATS/Conn.cs
+++ b/NATS/Conn.cs
@@ -989,7 +989,7 @@ namespace NATS.Client
             catch (Exception e)
             {
                 processOpError(e);
-                throw e;
+                throw;
             }
             finally
             {


### PR DESCRIPTION
`Conn.processExpectedInfo` loses the stack trace via `throw e`, switched to a bare `throw` to rethrow with the correct context.
