### PR TITLE
Convert tests to XUnit

### DIFF
--- a/NATS.sln
+++ b/NATS.sln
@@ -1,11 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 2013 for Windows Desktop
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NATS", "NATS\NATS.csproj", "{68EE71D4-9532-470E-B5CA-ECAA79936B1F}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NATSUnitTests", "NATSUnitTests\NATSUnitTests.csproj", "{00DBFD4D-72F4-4250-884C-C1527C66A0C2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Publish", "examples\Publish\Publish.csproj", "{A434BE66-EC4D-4FA4-89C7-9097A22319FF}"
 EndProject
@@ -19,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Replier", "examples\Replier
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark", "examples\Benchmark\Benchmark.csproj", "{98F344E4-B714-4C23-96AF-D6F6F0420944}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NATSUnitTests", "NATSUnitTests\NATSUnitTests.csproj", "{83937CFE-167C-4913-8489-95CC196EE728}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,10 +29,6 @@ Global
 		{68EE71D4-9532-470E-B5CA-ECAA79936B1F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{68EE71D4-9532-470E-B5CA-ECAA79936B1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{68EE71D4-9532-470E-B5CA-ECAA79936B1F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{00DBFD4D-72F4-4250-884C-C1527C66A0C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{00DBFD4D-72F4-4250-884C-C1527C66A0C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{00DBFD4D-72F4-4250-884C-C1527C66A0C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{00DBFD4D-72F4-4250-884C-C1527C66A0C2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A434BE66-EC4D-4FA4-89C7-9097A22319FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A434BE66-EC4D-4FA4-89C7-9097A22319FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A434BE66-EC4D-4FA4-89C7-9097A22319FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -57,6 +53,10 @@ Global
 		{98F344E4-B714-4C23-96AF-D6F6F0420944}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{98F344E4-B714-4C23-96AF-D6F6F0420944}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{98F344E4-B714-4C23-96AF-D6F6F0420944}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83937CFE-167C-4913-8489-95CC196EE728}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83937CFE-167C-4913-8489-95CC196EE728}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83937CFE-167C-4913-8489-95CC196EE728}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83937CFE-167C-4913-8489-95CC196EE728}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NATSUnitTests/NATSUnitTests.csproj
+++ b/NATSUnitTests/NATSUnitTests.csproj
@@ -1,21 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{00DBFD4D-72F4-4250-884C-C1527C66A0C2}</ProjectGuid>
+    <ProjectGuid>{83937CFE-167C-4913-8489-95CC196EE728}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NATSUnitTests</RootNamespace>
     <AssemblyName>NATSUnitTests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -26,7 +21,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -35,86 +29,114 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
-  <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
   <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Settings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
     <Compile Include="Settings.cs" />
+    <Compile Include="UnitTestAuth.cs" />
+    <Compile Include="UnitTestBasic.cs" />
+    <Compile Include="UnitTestCluster.cs" />
+    <Compile Include="UnitTestConn.cs" />
     <Compile Include="UnitTestEncoding.cs" />
     <Compile Include="UnitTestNUID.cs" />
-    <Compile Include="UnitTestTLS.cs" />
-    <Compile Include="UnitTestCluster.cs" />
     <Compile Include="UnitTestReconnect.cs" />
     <Compile Include="UnitTestSub.cs" />
+    <Compile Include="UnitTestTLS.cs" />
     <Compile Include="UnitTestUtilities.cs" />
-    <Compile Include="UnitTestConn.cs" />
-    <Compile Include="UnitTestBasic.cs" />
-    <Compile Include="UnitTestAuth.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\NATS\NATS.csproj">
-      <Project>{68ee71d4-9532-470e-b5ca-ecaa79936b1f}</Project>
-      <Name>NATS</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="config\auth_1223_timeout.conf" />
-    <None Include="config\auth_1224.conf" />
-    <None Include="config\auth_1222.conf" />
-    <None Include="config\auth_tls_1222.conf" />
-    <None Include="config\auth_tls_1223_timeout.conf" />
-    <None Include="config\auth_tls_1224.conf" />
-    <None Include="config\tls_1224.conf" />
-    <None Include="config\tls_1222.conf" />
-    <None Include="config\tls_1222_user.conf" />
-    <None Include="config\tls_1222_verify.conf" />
+    <None Include="config\auth_1222.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\auth_1223_timeout.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\auth_1224.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\auth_tls_1222.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\auth_tls_1223_timeout.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\auth_tls_1224.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\certs\ca.pem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\certs\client-cert.pem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\certs\client-key.pem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\certs\client.pfx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\certs\server-cert.pem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\certs\server-key.pem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\tls_1222.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\tls_1222_user.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\tls_1222_verify.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="config\tls_1224.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>
-  <ItemGroup />
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <ItemGroup>
+    <ProjectReference Include="..\NATS\NATS.csproj">
+      <Project>{68EE71D4-9532-470E-B5CA-ECAA79936B1F}</Project>
+      <Name>NATS</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/NATSUnitTests/NATSUnitTests.csproj
+++ b/NATSUnitTests/NATSUnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -137,7 +140,16 @@
       <Name>NATS</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/NATSUnitTests/Properties/AssemblyInfo.cs
+++ b/NATSUnitTests/Properties/AssemblyInfo.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("NATSUnitTests")]
@@ -16,8 +15,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -27,11 +26,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/NATSUnitTests/Properties/AssemblyInfo.cs
+++ b/NATSUnitTests/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -35,3 +36,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/NATSUnitTests/Properties/Settings.Designer.cs
+++ b/NATSUnitTests/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace NATSUnitTests.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "12.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/NATSUnitTests/UnitTestAuth.cs
+++ b/NATSUnitTests/UnitTestAuth.cs
@@ -29,27 +29,19 @@ namespace NATSUnitTests
                 Options opts = ConnectionFactory.GetDefaultOptions();
                 opts.Url = url;
                 opts.DisconnectedEventHandler += handleDisconnect;
-                IConnection c = new ConnectionFactory().CreateConnection(url);
+                IConnection c = null;
 
-                Assert.Fail("Expected a failure; did not receive one");
-                
+                Assert.ThrowsAny<Exception>(() => c = new ConnectionFactory().CreateConnection(url));
+
                 c.Close();
             }
             catch (Exception e)
             {
-                if (e.Message.Contains("Authorization"))
-                {
-                    System.Console.WriteLine("Success with expected failure: " + e.Message);
-                }
-                else
-                {
-                    Assert.Fail("Unexpected exception thrown: " + e);
-                }
+                Assert.True(e.Message.Contains("Authorization"));
             }
             finally
             {
-                if (hitDisconnect > 0)
-                    Assert.Fail("The disconnect event handler was incorrectly invoked.");
+                Assert.False(hitDisconnect > 0, "The disconnect event handler was incorrectly invoked.");
             }
         }
 

--- a/NATSUnitTests/UnitTestAuth.cs
+++ b/NATSUnitTests/UnitTestAuth.cs
@@ -23,15 +23,14 @@ namespace NATSUnitTests
         {
             try
             {
-                System.Console.WriteLine("Trying: " + url);
+                Console.WriteLine("Trying: " + url);
 
                 hitDisconnect = 0;
                 Options opts = ConnectionFactory.GetDefaultOptions();
                 opts.Url = url;
                 opts.DisconnectedEventHandler += handleDisconnect;
-                IConnection c = null;
-
-                Assert.ThrowsAny<Exception>(() => c = new ConnectionFactory().CreateConnection(url));
+                IConnection c = new ConnectionFactory().CreateConnection(url);
+                Assert.True(false, "Expected a failure; did not receive one");
 
                 c.Close();
             }
@@ -63,40 +62,24 @@ namespace NATSUnitTests
         [Fact]
         public void TestAuthFailure()
         {
-            try
+            using (NATSServer s = util.CreateServerWithConfig("auth_1222.conf"))
             {
-                using (NATSServer s = util.CreateServerWithConfig("auth_1222.conf"))
-                {
-                    connectAndFail("nats://username@localhost:1222");
-                    connectAndFail("nats://username:badpass@localhost:1222");
-                    connectAndFail("nats://localhost:1222");
-                    connectAndFail("nats://badname:password@localhost:1222");
-                }
-            }
-            catch (Exception e)
-            {
-                System.Console.WriteLine(e);
-                throw e;
+                connectAndFail("nats://username@localhost:1222");
+                connectAndFail("nats://username:badpass@localhost:1222");
+                connectAndFail("nats://localhost:1222");
+                connectAndFail("nats://badname:password@localhost:1222");
             }
         }
 
         [Fact]
         public void TestAuthToken()
         {
-            try
+            using (NATSServer s = util.CreateServerWithArgs("-auth S3Cr3T0k3n!"))
             {
-                using (NATSServer s = util.CreateServerWithArgs("-auth S3Cr3T0k3n!"))
-                {
-                    connectAndFail("nats://localhost:4222");
-                    connectAndFail("nats://invalid_token@localhost:4222");
+                connectAndFail("nats://localhost:4222");
+                connectAndFail("nats://invalid_token@localhost:4222");
 
-                    new ConnectionFactory().CreateConnection("nats://S3Cr3T0k3n!@localhost:4222").Close();
-                }
-            }
-            catch (Exception e)
-            {
-                System.Console.WriteLine(e);
-                throw e;
+                new ConnectionFactory().CreateConnection("nats://S3Cr3T0k3n!@localhost:4222").Close();
             }
         }
 
@@ -115,7 +98,7 @@ namespace NATSUnitTests
 
                 opts.Servers = new string[]{
                     "nats://username:password@localhost:1222",
-                    "nats://username:password@localhost:1223", 
+                    "nats://username:password@localhost:1223",
                     "nats://username:password@localhost:1224" };
                 opts.NoRandomize = true;
 

--- a/NATSUnitTests/UnitTestBasic.cs
+++ b/NATSUnitTests/UnitTestBasic.cs
@@ -38,12 +38,12 @@ namespace NATSUnitTests
 
             Assert.False(string.IsNullOrWhiteSpace(u), $"Invalid connected url {u}.");
 
-            Assert.NotEqual(Defaults.Url, u);
+            Assert.Equal(Defaults.Url, u);
 
             c.Close();
             u = c.ConnectedUrl;
 
-            Assert.NotNull(u);
+            Assert.Null(u);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace NATSUnitTests
         {
             Options opts = ConnectionFactory.GetDefaultOptions();
 
-            Assert.Throws<Exception>(() => opts.Timeout = -1);
+            Assert.ThrowsAny<Exception>(() => opts.Timeout = -1);
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace NATSUnitTests
                         Monitor.Wait(mu, 30000);
                     }
 
-                    Assert.False(received, "Did not receive message.");
+                    Assert.True(received, "Did not receive message.");
                 }
             }
         }

--- a/NATSUnitTests/UnitTestCluster.cs
+++ b/NATSUnitTests/UnitTestCluster.cs
@@ -40,16 +40,12 @@ namespace NATSUnitTests
 
             o.NoRandomize = true;
 
-            UnitTestUtilities.testExpectedException(
-                () => { cf.CreateConnection(); },
-                typeof(NATSNoServersException));
+            Assert.ThrowsAny<NATSNoServersException>(() => cf.CreateConnection());
 
             o.Servers = testServers;
 
-            UnitTestUtilities.testExpectedException(
-                () => { cf.CreateConnection(o); },
-                typeof(NATSNoServersException));
-
+            Assert.ThrowsAny<NATSNoServersException>(() => cf.CreateConnection(o));
+            
             // Make sure we can connect to first server if running
             using (NATSServer ns = utils.CreateServerOnPort(1222))
             {
@@ -83,9 +79,7 @@ namespace NATSUnitTests
             using (NATSServer as1 = utils.CreateServerWithConfig("auth_1222.conf"),
                               as2 = utils.CreateServerWithConfig("auth_1224.conf"))
             {
-                UnitTestUtilities.testExpectedException(
-                    () => { new ConnectionFactory().CreateConnection(opts); },
-                    typeof(NATSException));
+                Assert.ThrowsAny<NATSException>(() => new ConnectionFactory().CreateConnection(opts));
 
                 // Test that we can connect to a subsequent correct server.
                 string[] authServers = new string[] {

--- a/NATSUnitTests/UnitTestCluster.cs
+++ b/NATSUnitTests/UnitTestCluster.cs
@@ -90,7 +90,7 @@ namespace NATSUnitTests
 
                 using (IConnection c = new ConnectionFactory().CreateConnection(opts))
                 {
-                    Assert.True(c.ConnectedUrl.Equals(authServers[1]));
+                    Assert.Equal(authServers[1], c.ConnectedUrl);
                 }
             }
         }

--- a/NATSUnitTests/UnitTestCluster.cs
+++ b/NATSUnitTests/UnitTestCluster.cs
@@ -1,37 +1,19 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NATS.Client;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
+using Xunit;
 
 namespace NATSUnitTests
 {
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    [TestClass]
     public class TestCluster
     {
-        private TestContext testContextInstance;
-        /// <summary>
-        ///Gets or sets the test context which provides
-        ///information about and functionality for the current test run.
-        ///</summary>
-        public TestContext TestContext
-        {
-            get
-            {
-                return testContextInstance;
-            }
-            set
-            {
-                testContextInstance = value;
-            }
-        }
-
         string[] testServers = new string[] {
             "nats://localhost:1222",
             "nats://localhost:1223",
@@ -49,7 +31,7 @@ namespace NATSUnitTests
 
         UnitTestUtilities utils = new UnitTestUtilities();
 
-        [TestMethod]
+        [Fact]
         public void TestServersOption()
         {
             IConnection c = null;
@@ -72,7 +54,7 @@ namespace NATSUnitTests
             using (NATSServer ns = utils.CreateServerOnPort(1222))
             {
                 c = cf.CreateConnection(o);
-                Assert.IsTrue(testServers[0].Equals(c.ConnectedUrl));
+                Assert.True(testServers[0].Equals(c.ConnectedUrl));
                 c.Close();
             }
 
@@ -80,12 +62,12 @@ namespace NATSUnitTests
             using (NATSServer ns = utils.CreateServerOnPort(1227))
             {
                 c = cf.CreateConnection(o);
-                Assert.IsTrue(testServers[5].Equals(c.ConnectedUrl));
+                Assert.True(testServers[5].Equals(c.ConnectedUrl));
                 c.Close();
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestAuthServers()
         {
             string[] plainServers = new string[] {
@@ -98,8 +80,8 @@ namespace NATSUnitTests
             opts.Servers = plainServers;
             opts.Timeout = 5000;
 
-            using (NATSServer as1 = utils.CreateServerWithConfig(TestContext, "auth_1222.conf"),
-                              as2 = utils.CreateServerWithConfig(TestContext, "auth_1224.conf"))
+            using (NATSServer as1 = utils.CreateServerWithConfig("auth_1222.conf"),
+                              as2 = utils.CreateServerWithConfig("auth_1224.conf"))
             {
                 UnitTestUtilities.testExpectedException(
                     () => { new ConnectionFactory().CreateConnection(opts); },
@@ -114,12 +96,12 @@ namespace NATSUnitTests
 
                 using (IConnection c = new ConnectionFactory().CreateConnection(opts))
                 {
-                    Assert.IsTrue(c.ConnectedUrl.Equals(authServers[1]));
+                    Assert.True(c.ConnectedUrl.Equals(authServers[1]));
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestBasicClusterReconnect()
         {
             string[] plainServers = new string[] {
@@ -168,17 +150,17 @@ namespace NATSUnitTests
                     lock (disconnectLock)
                     {
                         s1.Shutdown();
-                        Assert.IsTrue(Monitor.Wait(disconnectLock, 20000));
+                        Assert.True(Monitor.Wait(disconnectLock, 20000));
                     }
 
                     reconnectSw.Start();
 
                     lock (reconnectLock)
                     {
-                        Assert.IsTrue(Monitor.Wait(reconnectLock, 20000));
+                        Assert.True(Monitor.Wait(reconnectLock, 20000));
                     }
 
-                    Assert.IsTrue(c.ConnectedUrl.Equals(testServers[2]));
+                    Assert.True(c.ConnectedUrl.Equals(testServers[2]));
 
                     reconnectSw.Stop();
 
@@ -235,7 +217,7 @@ namespace NATSUnitTests
         }
 
 
-        // TODO:  Create smaller variant [TestMethod]
+        // TODO:  Create smaller variant [Fact]
         public void TestHotSpotReconnect()
         {
             int numClients = 10;
@@ -280,17 +262,15 @@ namespace NATSUnitTests
                     unknown++;
             }
 
-            Assert.IsTrue(unknown == 0);
+            Assert.True(unknown == 0);
             int delta = Math.Abs(s2Count - s3Count);
             int range = numClients / 30;
-            if (delta > range)
-            {
-                Assert.Fail("Connected clients to servers out of range: {0}/{1}", delta, range);
-            }
+
+            Assert.False(delta > range, $"Connected clients to servers out of range: {delta}/{range}");
 
         }
 
-        [TestMethod]
+        [Fact]
         public void TestProperReconnectDelay()
         {
             Object mu = new Object();
@@ -324,22 +304,22 @@ namespace NATSUnitTests
                 {
                     s1.Shutdown();
                     // wait for disconnect
-                    Assert.IsTrue(Monitor.Wait(mu, 10000));
+                    Assert.True(Monitor.Wait(mu, 10000));
 
 
                     // Wait, want to make sure we don't spin on
                     //reconnect to non-existant servers.
                     Thread.Sleep(1000);
 
-                    Assert.IsFalse(closedCbCalled);
-                    Assert.IsTrue(disconnectHandlerCalled);
-                    Assert.IsTrue(c.State == ConnState.RECONNECTING);
+                    Assert.False(closedCbCalled);
+                    Assert.True(disconnectHandlerCalled);
+                    Assert.True(c.State == ConnState.RECONNECTING);
                 }
 
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestProperFalloutAfterMaxAttempts()
         {
             Options opts = ConnectionFactory.GetDefaultOptions();
@@ -383,23 +363,23 @@ namespace NATSUnitTests
                     lock (dmu)
                     {
                         if (!disconnectHandlerCalled)
-                            Assert.IsTrue(Monitor.Wait(dmu, 20000));
+                            Assert.True(Monitor.Wait(dmu, 20000));
                     }
 
                     lock (cmu)
                     {
                         if (!closedHandlerCalled)
-                            Assert.IsTrue(Monitor.Wait(cmu, 60000));
+                            Assert.True(Monitor.Wait(cmu, 60000));
                     }
 
-                    Assert.IsTrue(disconnectHandlerCalled);
-                    Assert.IsTrue(closedHandlerCalled);
-                    Assert.IsTrue(c.IsClosed());
+                    Assert.True(disconnectHandlerCalled);
+                    Assert.True(closedHandlerCalled);
+                    Assert.True(c.IsClosed());
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestProperFalloutAfterMaxAttemptsWithAuthMismatch()
         {
             Options opts = ConnectionFactory.GetDefaultOptions();
@@ -439,7 +419,7 @@ namespace NATSUnitTests
             };
 
             using (NATSServer s1 = utils.CreateServerOnPort(1220),
-                   s2 = utils.CreateServerWithConfig(testContextInstance, "tls_1222_verify.conf"))
+                   s2 = utils.CreateServerWithConfig("tls_1222_verify.conf"))
             {
                 using (IConnection c = new ConnectionFactory().CreateConnection(opts))
                 {
@@ -448,25 +428,25 @@ namespace NATSUnitTests
                     lock (dmu)
                     {
                         if (!disconnectHandlerCalled)
-                            Assert.IsTrue(Monitor.Wait(dmu, 20000));
+                            Assert.True(Monitor.Wait(dmu, 20000));
                     }
 
                     lock (cmu)
                     {
                         if (!closedHandlerCalled)
-                            Assert.IsTrue(Monitor.Wait(cmu, 600000));
+                            Assert.True(Monitor.Wait(cmu, 600000));
                     }
 
-                    Assert.IsTrue(c.Stats.Reconnects != opts.MaxReconnect);
+                    Assert.True(c.Stats.Reconnects != opts.MaxReconnect);
 
-                    Assert.IsTrue(disconnectHandlerCalled);
-                    Assert.IsTrue(closedHandlerCalled);
-                    Assert.IsTrue(c.IsClosed());
+                    Assert.True(disconnectHandlerCalled);
+                    Assert.True(closedHandlerCalled);
+                    Assert.True(c.IsClosed());
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTimeoutOnNoServers()
         {
             Options opts = ConnectionFactory.GetDefaultOptions();
@@ -508,7 +488,7 @@ namespace NATSUnitTests
                     lock (dmu)
                     {
                         if (!disconnectHandlerCalled)
-                           Assert.IsTrue(Monitor.Wait(dmu, 20000));
+                           Assert.True(Monitor.Wait(dmu, 20000));
                     }
 
                     Stopwatch sw = new Stopwatch();
@@ -517,7 +497,7 @@ namespace NATSUnitTests
                     lock (cmu)
                     {
                         if (!closedHandlerCalled)
-                            Assert.IsTrue(Monitor.Wait(cmu, 60000));
+                            Assert.True(Monitor.Wait(cmu, 60000));
                     }
 
                     sw.Stop();
@@ -528,14 +508,14 @@ namespace NATSUnitTests
                     // a connect timeout has been added.
                     //Assert.IsTrue(sw.ElapsedMilliseconds < (expected + 500));
 
-                    Assert.IsTrue(disconnectHandlerCalled);
-                    Assert.IsTrue(closedHandlerCalled);
-                    Assert.IsTrue(c.IsClosed());
+                    Assert.True(disconnectHandlerCalled);
+                    Assert.True(closedHandlerCalled);
+                    Assert.True(c.IsClosed());
                 }
             }
         }
 
-        //[TestMethod]
+        //[Fact]
         public void TestPingReconnect()
         {
             /// Work in progress
@@ -579,7 +559,7 @@ namespace NATSUnitTests
                     {
                         lock (mu)
                         {
-                            Assert.IsTrue(Monitor.Wait(mu, 100000));
+                            Assert.True(Monitor.Wait(mu, 100000));
                         }
                     }
                 }

--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -190,20 +190,20 @@ namespace NATSUnitTests
                     Thread.Sleep(100);
                     if (firstDisconnect)
                     {
-                        System.Console.WriteLine("First disconnect.");
+                        Console.WriteLine("First disconnect.");
                         firstDisconnect = false;
                         dtime1 = DateTime.Now.Ticks;
                     }
                     else
                     {
-                        System.Console.WriteLine("Second disconnect.");
+                        Console.WriteLine("Second disconnect.");
                         dtime2 = DateTime.Now.Ticks;
                     }
                 };
 
                 o.ReconnectedEventHandler += (sender, args) =>
                 {
-                    System.Console.WriteLine("Reconnected.");
+                    Console.WriteLine("Reconnected.");
                     Thread.Sleep(50);
                     rtime = DateTime.Now.Ticks;
                     reconnected.notify();
@@ -213,14 +213,14 @@ namespace NATSUnitTests
                 {
                     if (args.Subscription.Subject.Equals("foo"))
                     {
-                        System.Console.WriteLine("Error handler foo.");
+                        Console.WriteLine("Error handler foo.");
                         Thread.Sleep(200);
                         atime1 = DateTime.Now.Ticks;
                         asyncErr1.notify();
                     }
                     else
                     {
-                        System.Console.WriteLine("Error handler bar.");
+                        Console.WriteLine("Error handler bar.");
                         atime2 = DateTime.Now.Ticks;
                         asyncErr2.notify();
                     }
@@ -228,7 +228,7 @@ namespace NATSUnitTests
 
                 o.ClosedEventHandler += (sender, args) =>
                 {
-                    System.Console.WriteLine("Closed handler.");
+                    Console.WriteLine("Closed handler.");
                     ctime = DateTime.Now.Ticks;
                     closed.notify();
                 };
@@ -251,7 +251,7 @@ namespace NATSUnitTests
 
                     EventHandler<MsgHandlerEventArgs> eh = (sender, args) =>
                     {
-                        System.Console.WriteLine("Received message on subject: " + args.Message.Subject);
+                        Console.WriteLine("Received message on subject: " + args.Message.Subject);
                         recvCh.notify();
                         if (args.Message.Subject.Equals("foo"))
                         {
@@ -298,14 +298,14 @@ namespace NATSUnitTests
                 if (dtime1 == orig || dtime2 == orig || rtime == orig || 
                     atime1 == orig || atime2 == orig || ctime == orig)
                 {
-                    System.Console.WriteLine("Error = callback didn't fire: {0}\n{1}\n{2}\n{3}\n{4}\n{5}\n",
+                    Console.WriteLine("Error = callback didn't fire: {0}\n{1}\n{2}\n{3}\n{4}\n{5}\n",
                         dtime1, dtime2, rtime, atime1, atime2, ctime);
                     throw new Exception("Callback didn't fire.");
                 }
 
                 if (rtime < dtime1 || dtime2 < rtime || atime2 < atime1|| ctime < atime2) 
                 {
-                    System.Console.WriteLine("Wrong callback order:{0}\n{1}\n{2}\n{3}\n{4}\n{5}\n",
+                    Console.WriteLine("Wrong callback order:{0}\n{1}\n{2}\n{3}\n{4}\n{5}\n",
                         dtime1, rtime, atime1, atime2, dtime2, ctime);
                     throw new Exception("Invalid callback order.");
  	            }

--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -125,49 +125,27 @@ namespace NATSUnitTests
 
             // While we can annotate all the exceptions in the test framework,
             // just do it manually.
-            UnitTestUtilities.testExpectedException(
-                () => { c.Publish("foo", null); }, 
-                typeof(NATSConnectionClosedException));
+            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.Publish("foo", null));
 
-            UnitTestUtilities.testExpectedException(
-                () => { c.Publish(new Msg("foo")); }, 
-                typeof(NATSConnectionClosedException));
+            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.Publish(new Msg("foo")));
 
-            UnitTestUtilities.testExpectedException(
-                () => { c.SubscribeAsync("foo"); },
-                typeof(NATSConnectionClosedException));
+            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeAsync("foo"));
 
-            UnitTestUtilities.testExpectedException(
-                () => { c.SubscribeSync("foo"); }, 
-                typeof(NATSConnectionClosedException));
+            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeSync("foo"));
 
-            UnitTestUtilities.testExpectedException(
-                () => { c.SubscribeAsync("foo", "bar"); },
-                typeof(NATSConnectionClosedException));
+            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeAsync("foo", "bar"));
 
-            UnitTestUtilities.testExpectedException(
-                () => { c.SubscribeSync("foo", "bar"); }, 
-                typeof(NATSConnectionClosedException));
+            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeSync("foo", "bar"));
 
-            UnitTestUtilities.testExpectedException(
-                () => { c.Request("foo", null); }, 
-                typeof(NATSConnectionClosedException));
+            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.Request("foo", null));
 
-            UnitTestUtilities.testExpectedException(
-                () => { s.NextMessage(); },
-                typeof(NATSConnectionClosedException));
+            Assert.ThrowsAny<NATSConnectionClosedException>(() => s.NextMessage());
 
-            UnitTestUtilities.testExpectedException(
-                () => { s.NextMessage(100); },
-                typeof(NATSConnectionClosedException));
+            Assert.ThrowsAny<NATSConnectionClosedException>(() => s.NextMessage(100));
 
-            UnitTestUtilities.testExpectedException(
-                () => { s.Unsubscribe(); }, 
-                typeof(NATSConnectionClosedException));
+            Assert.ThrowsAny<NATSConnectionClosedException>(() => s.Unsubscribe());
 
-            UnitTestUtilities.testExpectedException(
-                () => { s.AutoUnsubscribe(1); }, 
-                typeof(NATSConnectionClosedException));
+            Assert.ThrowsAny<NATSConnectionClosedException>(() => s.AutoUnsubscribe(1));
         }
 
         [Fact]

--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -1,61 +1,40 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NATS.Client;
 using System.Threading;
+using Xunit;
 
 namespace NATSUnitTests
 {
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    [TestClass]
-    public class TestConnection
+    public class TestConnection : IDisposable
     {
-
         UnitTestUtilities utils = new UnitTestUtilities();
-
-        private TestContext testContextInstance;
-        /// <summary>
-        ///Gets or sets the test context which provides
-        ///information about and functionality for the current test run.
-        ///</summary>
-        public TestContext TestContext
-        {
-            get
-            {
-                return testContextInstance;
-            }
-            set
-            {
-                testContextInstance = value;
-            }
-        }
-
-        [TestInitialize()]
-        public void Initialize()
+        
+        public TestConnection()
         {
             UnitTestUtilities.CleanupExistingServers();
             utils.StartDefaultServer();
         }
-
-        [TestCleanup()]
-        public void Cleanup()
+        
+        public void Dispose()
         {
             utils.StopDefaultServer();
         }
-
-        [TestMethod]
+        
+        [Fact]
         public void TestConnectionStatus()
         {
             IConnection c = new ConnectionFactory().CreateConnection();
-            Assert.AreEqual(ConnState.CONNECTED, c.State);
+            Assert.Equal(ConnState.CONNECTED, c.State);
             c.Close();
-            Assert.AreEqual(ConnState.CLOSED, c.State);
+            Assert.Equal(ConnState.CLOSED, c.State);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCloseHandler()
         {
             bool closed = false;
@@ -66,16 +45,16 @@ namespace NATSUnitTests
             IConnection c = new ConnectionFactory().CreateConnection(o);
             c.Close();
             Thread.Sleep(1000);
-            Assert.IsTrue(closed);
+            Assert.True(closed);
 
             // now test using.
             closed = false;
             using (c = new ConnectionFactory().CreateConnection(o)) { };
             Thread.Sleep(1000);
-            Assert.IsTrue(closed);
+            Assert.True(closed);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCloseDisconnectedHandler()
         {
             bool disconnected = false;
@@ -97,7 +76,7 @@ namespace NATSUnitTests
                 c.Close();
                 Monitor.Wait(mu, 20000);
             }
-            Assert.IsTrue(disconnected);
+            Assert.True(disconnected);
 
             // now test using.
             disconnected = false;
@@ -106,10 +85,10 @@ namespace NATSUnitTests
                 using (c = new ConnectionFactory().CreateConnection(o)) { };
                 Monitor.Wait(mu, 20000);
             }
-            Assert.IsTrue(disconnected);
+            Assert.True(disconnected);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestServerStopDisconnectedHandler()
         {
             bool disconnected = false;
@@ -133,10 +112,10 @@ namespace NATSUnitTests
                 Monitor.Wait(mu, 10000);
             }
             c.Close();
-            Assert.IsTrue(disconnected);
+            Assert.True(disconnected);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestClosedConnections()
         {
             IConnection c = new ConnectionFactory().CreateConnection();
@@ -191,7 +170,7 @@ namespace NATSUnitTests
                 typeof(NATSConnectionClosedException));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestConnectVerbose()
         {
 
@@ -202,7 +181,7 @@ namespace NATSUnitTests
             c.Close();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCallbacksOrder()
         {
             bool firstDisconnect = true;
@@ -224,7 +203,7 @@ namespace NATSUnitTests
             ConditionalObj recvCh1     = new ConditionalObj();
             ConditionalObj recvCh2     = new ConditionalObj();
 
-            using (NATSServer s = utils.CreateServerWithConfig(TestContext, "auth_1222.conf"))
+            using (NATSServer s = utils.CreateServerWithConfig("auth_1222.conf"))
             {
                 Options o = ConnectionFactory.GetDefaultOptions();
 

--- a/NATSUnitTests/UnitTestEncoding.cs
+++ b/NATSUnitTests/UnitTestEncoding.cs
@@ -1,38 +1,35 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NATS.Client;
 using System.Threading;
 using System.Text;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Xml.Serialization;
 using System.IO;
+using Xunit;
 
 namespace NATSUnitTests
 {
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    [TestClass]
-    public class TestEncoding
+    public class TestEncoding : IDisposable
     {
         UnitTestUtilities utils = new UnitTestUtilities();
-
-        [TestInitialize()]
-        public void Initialize()
+        
+        public TestEncoding()
         {
             UnitTestUtilities.CleanupExistingServers();
             utils.StartDefaultServer();
         }
 
-        [TestCleanup()]
-        public void Cleanup()
+        public void Dispose()
         {
             utils.StopDefaultServer();
         }
-
-        [TestMethod]
+        
+        [Fact]
         public void TestEncodedObjectSerization()
         {
             using (IEncodedConnection c = new ConnectionFactory().CreateEncodedConnection())
@@ -42,7 +39,7 @@ namespace NATSUnitTests
 
                 EventHandler<EncodedMessageEventArgs> eh = (sender, args) =>
                 {
-                    Assert.IsTrue(args.ReceivedObject.Equals(myStr));
+                    Assert.True(args.ReceivedObject.Equals(myStr));
                     lock (mu)
                     {
                         Monitor.Pulse(mu);
@@ -75,7 +72,7 @@ namespace NATSUnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestEncodedInvalidObjectSerialization()
         {
             using (IEncodedConnection c = new ConnectionFactory().CreateEncodedConnection())
@@ -98,7 +95,7 @@ namespace NATSUnitTests
                         System.Console.WriteLine("Expected exception: " + e.Message);
                     }
 
-                    Assert.IsTrue(hitException);
+                    Assert.True(hitException);
 
                     lock (mu)
                     {
@@ -149,7 +146,7 @@ namespace NATSUnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCustomObjectSerialization()
         {
             using (IEncodedConnection c = new ConnectionFactory().CreateEncodedConnection())
@@ -161,7 +158,7 @@ namespace NATSUnitTests
                 {
                     // Ensure we blow up in the cast
                     SerializationTestObj so = (SerializationTestObj)args.ReceivedObject;
-                    Assert.IsTrue(so.Equals(origObj));
+                    Assert.True(so.Equals(origObj));
 
                     lock (mu)
                     {
@@ -207,7 +204,7 @@ namespace NATSUnitTests
             return x.Deserialize(ms);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestEncodedSerizationOverrides()
         {
             using (IEncodedConnection c = new ConnectionFactory().CreateEncodedConnection())
@@ -222,7 +219,7 @@ namespace NATSUnitTests
                 EventHandler<EncodedMessageEventArgs> eh = (sender, args) =>
                 {
                     SerializationTestObj so = (SerializationTestObj)args.ReceivedObject;
-                    Assert.IsTrue(so.Equals(origObj));
+                    Assert.True(so.Equals(origObj));
 
                     lock (mu)
                     {
@@ -243,7 +240,7 @@ namespace NATSUnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestEncodedObjectRequestReply()
         {
             using (IEncodedConnection c = new ConnectionFactory().CreateEncodedConnection())
@@ -254,7 +251,7 @@ namespace NATSUnitTests
                 EventHandler<EncodedMessageEventArgs> eh = (sender, args) =>
                 {
                     SerializationTestObj so = (SerializationTestObj)args.ReceivedObject;
-                    Assert.IsTrue(so.Equals(origObj));
+                    Assert.True(so.Equals(origObj));
                     String str = "Received";
 
                     c.Publish(args.Reply, str);
@@ -268,8 +265,8 @@ namespace NATSUnitTests
 
                 using (IAsyncSubscription s = c.SubscribeAsync("foo", eh))
                 {
-                    Assert.IsTrue("Received".Equals(c.Request("foo", origObj, 1000)));
-                    Assert.IsTrue("Received".Equals(c.Request("foo", origObj)));
+                    Assert.True("Received".Equals(c.Request("foo", origObj, 1000)));
+                    Assert.True("Received".Equals(c.Request("foo", origObj)));
                 }
             }
         }

--- a/NATSUnitTests/UnitTestNUID.cs
+++ b/NATSUnitTests/UnitTestNUID.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NATS.Client;
 using System.Threading;
 using System.Text;
@@ -10,25 +9,25 @@ using System.Xml.Serialization;
 using System.IO;
 using System.Diagnostics;
 using System.Collections.Generic;
+using Xunit;
 
 namespace NATS.Client
 {
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    [TestClass]
     public class TestNUID
     {
-        [TestMethod]
+        [Fact]
         public void TestGlobalNUID()
         {
             NUID n = NUID.Instance;
-            Assert.IsNotNull(n);
-            Assert.IsNotNull(n.Pre);
-            Assert.AreNotEqual(0, n.Seq);
+            Assert.NotNull(n);
+            Assert.NotNull(n.Pre);
+            Assert.NotEqual(0, n.Seq);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNUIDRollover()
         {
             NUID gnuid = NUID.Instance;
@@ -46,14 +45,14 @@ namespace NATS.Client
                     areEqual = false;
             }
 
-            Assert.IsFalse(areEqual);
+            Assert.False(areEqual);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNUIDLen()
         {
             string nuid = new NUID().Next;
-            Assert.IsTrue(nuid.Length == NUID.LENGTH);
+            Assert.Equal(nuid.Length, NUID.LENGTH);
         }
 
         static void printElapsedTime(long operations, Stopwatch sw)
@@ -61,7 +60,7 @@ namespace NATS.Client
             double nanoseconds = ((double)sw.ElapsedTicks /
                 ((double)Stopwatch.Frequency) * (double)1000000000);
             System.Console.WriteLine("Performed {0} operations in {1} nanos.  {2} ns/op",
-                operations, nanoseconds, (long)(nanoseconds /(double)operations));
+                operations, nanoseconds, (long)(nanoseconds / (double)operations));
         }
 
         private void runNUIDSpeedTest(NUID n)
@@ -80,19 +79,19 @@ namespace NATS.Client
             printElapsedTime(count, sw);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNUIDSpeed()
         {
             runNUIDSpeedTest(NUID.Instance);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGlobalNUIDSpeed()
         {
             runNUIDSpeedTest(new NUID());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNuidBasicUniqueess()
         {
             int count = 1000000;
@@ -101,14 +100,9 @@ namespace NATS.Client
             for (int i = 0; i < count; i++)
             {
                 String n = NUID.NextGlobal;
-                if (m.ContainsKey(n))
-                {
-                    Assert.Fail("Duplicate NUID found: " + n);
-                }
-                else
-                {
-                    m.Add(n, true);
-                }
+                Assert.False(m.ContainsKey(n), $"Duplicate NUID found: {n}");
+
+                m.Add(n, true);
             }
         }
 

--- a/NATSUnitTests/UnitTestNUID.cs
+++ b/NATSUnitTests/UnitTestNUID.cs
@@ -1,17 +1,12 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
 using System;
-using NATS.Client;
-using System.Threading;
-using System.Text;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Xml.Serialization;
-using System.IO;
-using System.Diagnostics;
 using System.Collections.Generic;
+using System.Diagnostics;
+using NATS.Client;
 using Xunit;
 
-namespace NATS.Client
+namespace NATSUnitTests
 {
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.

--- a/NATSUnitTests/UnitTestReconnect.cs
+++ b/NATSUnitTests/UnitTestReconnect.cs
@@ -393,7 +393,7 @@ namespace NATSUnitTests
                 s1.Shutdown();
 
                 Thread.Sleep(100);
-                Assert.True(c.IsClosed(), $"Invalid state, expecting not closed, received: {c.State}");
+                Assert.False(c.IsClosed(), $"Invalid state, expecting not closed, received: {c.State}");
                 
                 using (NATSServer s2 = utils.CreateServerOnPort(22222))
                 {

--- a/NATSUnitTests/UnitTestReconnect.cs
+++ b/NATSUnitTests/UnitTestReconnect.cs
@@ -1,20 +1,19 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NATS.Client;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Collections.Generic;
+using Xunit;
 
 namespace NATSUnitTests
 {
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    [TestClass]
     public class TestReconnect
     {
 
@@ -32,14 +31,13 @@ namespace NATSUnitTests
         }
 
         UnitTestUtilities utils = new UnitTestUtilities();
-
-        [TestInitialize()]
-        public void Initialize()
+        
+        public TestReconnect()
         {
             UnitTestUtilities.CleanupExistingServers();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestReconnectDisallowedFlags()
         {
             Options opts = ConnectionFactory.GetDefaultOptions();
@@ -63,13 +61,13 @@ namespace NATSUnitTests
                     lock (testLock)
                     {
                         ns.Shutdown();
-                        Assert.IsTrue(Monitor.Wait(testLock, 1000));
+                        Assert.True(Monitor.Wait(testLock, 1000));
                     }
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestReconnectAllowedFlags()
         {
             Options opts = ConnectionFactory.GetDefaultOptions();
@@ -94,16 +92,16 @@ namespace NATSUnitTests
                     lock (testLock)
                     {
                         ns.Shutdown();
-                        Assert.IsFalse(Monitor.Wait(testLock, 1000));
+                        Assert.False(Monitor.Wait(testLock, 1000));
                     }
 
-                    Assert.IsTrue(c.State == ConnState.RECONNECTING);
+                    Assert.True(c.State == ConnState.RECONNECTING);
                     c.Opts.ClosedEventHandler = null;
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestBasicReconnectFunctionality()
         {
             Options opts = ConnectionFactory.GetDefaultOptions();
@@ -147,7 +145,7 @@ namespace NATSUnitTests
                 lock (testLock)
                 {
                     ns.Shutdown();
-                    Assert.IsTrue(Monitor.Wait(testLock, 100000));
+                    Assert.True(Monitor.Wait(testLock, 100000));
                 }
 
                 System.Console.WriteLine("Sending message.");
@@ -159,17 +157,17 @@ namespace NATSUnitTests
                     lock (msgLock)
                     {
                         c.Flush(50000);
-                        Assert.IsTrue(Monitor.Wait(msgLock, 10000));
+                        Assert.True(Monitor.Wait(msgLock, 10000));
                     }
 
-                    Assert.IsTrue(c.Stats.Reconnects == 1);
+                    Assert.True(c.Stats.Reconnects == 1);
                 }
             }
         }
 
         int received = 0;
 
-        [TestMethod]
+        [Fact]
         public void TestExtendedReconnectFunctionality()
         {
             Options opts = reconnectOptions;
@@ -220,7 +218,7 @@ namespace NATSUnitTests
                     ns.Shutdown();
                     // server is stopped here.
 
-                    Assert.IsTrue(Monitor.Wait(disconnectedLock, 20000));
+                    Assert.True(Monitor.Wait(disconnectedLock, 20000));
                 }
 
                 // subscribe to bar while connected.
@@ -240,7 +238,7 @@ namespace NATSUnitTests
                     // wait for reconnect
                     lock (reconnectedLock)
                     {
-                        Assert.IsTrue(Monitor.Wait(reconnectedLock, 60000));
+                        Assert.True(Monitor.Wait(reconnectedLock, 60000));
                     }
 
                     c.Publish("foobar", payload);
@@ -263,15 +261,12 @@ namespace NATSUnitTests
                         lock (doneLock)
                         {
                             c.Publish("done", payload);
-                            Assert.IsTrue(Monitor.Wait(doneLock, 2000));
+                            Assert.True(Monitor.Wait(doneLock, 2000));
                         }
                     }
                 } // NATSServer
-
-                if (received != 4)
-                {
-                    Assert.Fail("Expected 4, received {0}.", received);
-                }
+                
+                Assert.Equal(4, received);
             }
         }
 
@@ -291,11 +286,8 @@ namespace NATSUnitTests
             {
                 for (int i = 0; i < numSent; i++)
                 {
-                    if (results.ContainsKey(i) == false)
-                    {
-                        Assert.Fail("Received incorrect number of messages, [%d] for seq: %d\n",
-                            results[i], i);
-                    }
+                    Assert.True(results.ContainsKey(i),
+                        $"Received incorrect number of messages, {results[i]} for seq: {i}");
                 }
 
                 results.Clear();
@@ -326,7 +318,7 @@ namespace NATSUnitTests
             checkResults(numToSend);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestQueueSubsOnReconnect()
         {
             Object reconnectLock = new Object();
@@ -378,14 +370,14 @@ namespace NATSUnitTests
                 // wait for reconnect
                 lock (reconnectLock)
                 {
-                    Assert.IsTrue(Monitor.Wait(reconnectLock, 3000));
+                    Assert.True(Monitor.Wait(reconnectLock, 3000));
                 }
 
                 sendAndCheckMsgs(ec, subj, 10);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestClose()
         {
             Options opts = ConnectionFactory.GetDefaultOptions();
@@ -396,29 +388,25 @@ namespace NATSUnitTests
             using (NATSServer s1 = utils.CreateServerOnPort(22222))
             {
                 IConnection c = new ConnectionFactory().CreateConnection(opts);
-                Assert.IsFalse(c.IsClosed());
+                Assert.False(c.IsClosed());
                 
                 s1.Shutdown();
 
                 Thread.Sleep(100);
-                if (c.IsClosed())
-                {
-                    Assert.Fail("Invalid state, expecting not closed, received: "
-                        + c.State.ToString());
-                }
+                Assert.True(c.IsClosed(), $"Invalid state, expecting not closed, received: {c.State}");
                 
                 using (NATSServer s2 = utils.CreateServerOnPort(22222))
                 {
                     Thread.Sleep(1000);
-                    Assert.IsFalse(c.IsClosed());
+                    Assert.False(c.IsClosed());
                 
                     c.Close();
-                    Assert.IsTrue(c.IsClosed());
+                    Assert.True(c.IsClosed());
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestIsReconnectingAndStatus()
         {
             bool disconnected = false;
@@ -458,19 +446,19 @@ namespace NATSUnitTests
             {
                 c = new ConnectionFactory().CreateConnection(opts);
 
-                Assert.IsTrue(c.State == ConnState.CONNECTED);
-                Assert.IsTrue(c.IsReconnecting() == false);
+                Assert.True(c.State == ConnState.CONNECTED);
+                Assert.True(c.IsReconnecting() == false);
             }
             // server stops here...
 
             lock (disconnectedLock)
             {
                 if (!disconnected)
-                    Assert.IsTrue(Monitor.Wait(disconnectedLock, 10000));
+                    Assert.True(Monitor.Wait(disconnectedLock, 10000));
             }
 
-            Assert.IsTrue(c.State == ConnState.RECONNECTING);
-            Assert.IsTrue(c.IsReconnecting() == true);
+            Assert.True(c.State == ConnState.RECONNECTING);
+            Assert.True(c.IsReconnecting() == true);
 
             // restart the server
             using (NATSServer s = utils.CreateServerOnPort(22222))
@@ -479,22 +467,22 @@ namespace NATSUnitTests
                 {
                     // may have reconnected, if not, wait
                     if (!reconnected)
-                        Assert.IsTrue(Monitor.Wait(reconnectedLock, 10000));
+                        Assert.True(Monitor.Wait(reconnectedLock, 10000));
                 }
 
-                Assert.IsTrue(c.IsReconnecting() == false);
-                Assert.IsTrue(c.State == ConnState.CONNECTED);
+                Assert.True(c.IsReconnecting() == false);
+                Assert.True(c.State == ConnState.CONNECTED);
 
                 c.Close();
             }
 
-            Assert.IsTrue(c.IsReconnecting() == false);
-            Assert.IsTrue(c.State == ConnState.CLOSED);
+            Assert.True(c.IsReconnecting() == false);
+            Assert.True(c.State == ConnState.CLOSED);
 
         }
 
 
-        [TestMethod]
+        [Fact]
         public void TestReconnectVerbose()
         {
             // an exception stops and fails the test.

--- a/NATSUnitTests/UnitTestSub.cs
+++ b/NATSUnitTests/UnitTestSub.cs
@@ -515,12 +515,6 @@ namespace NATSUnitTests
                 Assert.ThrowsAny<Exception>(() => s.PendingByteLimit);
 
                 Assert.ThrowsAny<Exception>(() => s.SetPendingLimits(1, 10));
-
-                Assert.ThrowsAny<Exception>(() => s.ClearMaxPending());
-
-                Assert.ThrowsAny<Exception>(() => s.Delivered);
-
-                Assert.ThrowsAny<Exception>(() => s.Dropped);
             }
         }
 

--- a/NATSUnitTests/UnitTestSub.cs
+++ b/NATSUnitTests/UnitTestSub.cs
@@ -41,7 +41,7 @@ namespace NATSUnitTests
                 {
                     s.MessageHandler += (sender, arg) =>
                     {
-                        System.Console.WriteLine("Received msg.");
+                        Console.WriteLine("Received msg.");
                         received++;
                     };
 
@@ -172,13 +172,7 @@ namespace NATSUnitTests
                             // ignore
                         }
 
-                        try
-                        {
-                            s.NextMessage();
-                        }
-                        catch (NATSSlowConsumerException)
-                        {
-                        }
+                        s.NextMessage();
                     });
                 }
             }
@@ -268,7 +262,7 @@ namespace NATSUnitTests
 
                             Assert.True(args.Subscription == s);
 
-                            System.Console.WriteLine("Expected Error: " + args.Error);
+                            Console.WriteLine("Expected Error: " + args.Error);
                             Assert.True(args.Error.Contains("Slow"));
 
                             // release the subscriber
@@ -331,7 +325,7 @@ namespace NATSUnitTests
                 {
                     helper.MessageHandler += (sender, arg) =>
                     {
-                        System.Console.WriteLine("Helper");
+                        Console.WriteLine("Helper");
                         c.Publish(arg.Message.Reply,
                             Encoding.UTF8.GetBytes("Hello"));
                     };
@@ -339,13 +333,13 @@ namespace NATSUnitTests
 
                     start.MessageHandler += (sender, arg) =>
                     {
-                        System.Console.WriteLine("Responsder");
+                        Console.WriteLine("Responsder");
                         string responseIB = c.NewInbox();
                         IAsyncSubscription ia = c.SubscribeAsync(responseIB);
 
                         ia.MessageHandler += (iSender, iArgs) =>
                         {
-                            System.Console.WriteLine("Internal subscriber.");
+                            Console.WriteLine("Internal subscriber.");
                             lock (waitCond) { Monitor.Pulse(waitCond); }
                         };
                         ia.Start();
@@ -439,7 +433,7 @@ namespace NATSUnitTests
             ConditionalObj subDoneCond = new ConditionalObj();
             ConditionalObj startProcessing = new ConditionalObj();
 
-            byte[] data = System.Text.Encoding.UTF8.GetBytes("0123456789");
+            byte[] data = Encoding.UTF8.GetBytes("0123456789");
 
             using (IConnection c = new ConnectionFactory().CreateConnection())
             {
@@ -538,7 +532,7 @@ namespace NATSUnitTests
             ConditionalObj subDoneCond = new ConditionalObj();
             ConditionalObj startProcessing = new ConditionalObj();
 
-            byte[] data = System.Text.Encoding.UTF8.GetBytes("0123456789");
+            byte[] data = Encoding.UTF8.GetBytes("0123456789");
 
             using (IConnection c = new ConnectionFactory().CreateConnection())
             {
@@ -584,7 +578,7 @@ namespace NATSUnitTests
         {
             int total = 100;
 
-            byte[] data = System.Text.Encoding.UTF8.GetBytes("0123456789");
+            byte[] data = Encoding.UTF8.GetBytes("0123456789");
 
             using (IConnection c = new ConnectionFactory().CreateConnection())
             {
@@ -614,7 +608,7 @@ namespace NATSUnitTests
         {
             int total = 100;
 
-            byte[] data = System.Text.Encoding.UTF8.GetBytes("0123456789");
+            byte[] data = Encoding.UTF8.GetBytes("0123456789");
 
             using (IConnection c = new ConnectionFactory().CreateConnection())
             {

--- a/NATSUnitTests/UnitTestTLS.cs
+++ b/NATSUnitTests/UnitTestTLS.cs
@@ -31,27 +31,19 @@ namespace NATSUnitTests
                 Options opts = ConnectionFactory.GetDefaultOptions();
                 opts.Url = url;
                 opts.DisconnectedEventHandler += handleDisconnect;
-                IConnection c = new ConnectionFactory().CreateConnection(url);
+                IConnection c = null;
 
-                Assert.Fail("Expected a failure; did not receive one");
+                Assert.ThrowsAny<Exception>(() => c = new ConnectionFactory().CreateConnection(url));
                 
                 c.Close();
             }
             catch (Exception e)
             {
-                if (e.Message.Contains("Authorization"))
-                {
-                    Console.WriteLine("Success with expected failure: " + e.Message);
-                }
-                else
-                {
-                    Assert.Fail("Unexpected exception thrown: " + e);
-                }
+                Assert.True(e.Message.Contains("Authorization"));
             }
             finally
             {
-                if (hitDisconnect > 0)
-                    Assert.Fail("The disconnect event handler was incorrectly invoked.");
+                Assert.False(hitDisconnect > 0, "The disconnect event handler was incorrectly invoked.");
             }
         }
 
@@ -133,17 +125,7 @@ namespace NATSUnitTests
                 // key.
                 opts.AddCertificate(UnitTestUtilities.GetFullCertificatePath("client-cert.pem"));
 
-                try
-                {
-                    new ConnectionFactory().CreateConnection(opts);
-                }
-                catch (NATSException nae)     
-                {
-                    Console.WriteLine("Caught expected exception: " + nae.Message);
-                    return;
-                }
-
-                Assert.Fail("Did not receive exception.");
+                Assert.ThrowsAny<NATSException>(() => new ConnectionFactory().CreateConnection(opts));
             }
         }
 
@@ -161,18 +143,7 @@ namespace NATSUnitTests
                 // key.
                 opts.AddCertificate(UnitTestUtilities.GetFullCertificatePath("client-cert.pem"));
 
-                try
-                {
-                    new ConnectionFactory().CreateConnection(opts);
-                }
-                catch (NATSException nae)
-                {
-                    Console.WriteLine("Caught expected exception: " + nae.Message);
-                    Console.WriteLine("Exception output:" + nae);
-                    return;
-                }
-
-                Assert.Fail("Did not receive exception.");
+                Assert.ThrowsAny<NATSException>(() => new ConnectionFactory().CreateConnection(opts));
             }
         }
 

--- a/NATSUnitTests/UnitTestTLS.cs
+++ b/NATSUnitTests/UnitTestTLS.cs
@@ -3,39 +3,20 @@
 using System;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NATS.Client;
 using System.Reflection;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Xunit;
 
 namespace NATSUnitTests
 {
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    [TestClass]
     public class TestTLS
     {
-
-        private TestContext testContextInstance;
-        /// <summary>
-        ///Gets or sets the test context which provides
-        ///information about and functionality for the current test run.
-        ///</summary>
-        public TestContext TestContext
-        {
-            get
-            {
-                return testContextInstance;
-            }
-            set
-            {
-                testContextInstance = value;
-            }
-        }
-
         int hitDisconnect;
 
         UnitTestUtilities util = new UnitTestUtilities();
@@ -44,7 +25,7 @@ namespace NATSUnitTests
         {
             try
             {
-                System.Console.WriteLine("Trying: " + url);
+                Console.WriteLine("Trying: " + url);
 
                 hitDisconnect = 0;
                 Options opts = ConnectionFactory.GetDefaultOptions();
@@ -60,7 +41,7 @@ namespace NATSUnitTests
             {
                 if (e.Message.Contains("Authorization"))
                 {
-                    System.Console.WriteLine("Success with expected failure: " + e.Message);
+                    Console.WriteLine("Success with expected failure: " + e.Message);
                 }
                 else
                 {
@@ -96,8 +77,7 @@ namespace NATSUnitTests
                 return true;
 
             X509Certificate serverCert = new X509Certificate(
-                    UnitTestUtilities.GetFullCertificatePath(
-                    TestContext, "server-cert.pem"));
+                    UnitTestUtilities.GetFullCertificatePath("server-cert.pem"));
 
             // UNSAFE hack for testing purposes.
             if (serverCert.GetRawCertDataString().Equals(certificate.GetRawCertDataString()))
@@ -106,10 +86,10 @@ namespace NATSUnitTests
             return false;
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTlsSuccessWithCert()
         {
-            using (NATSServer srv = util.CreateServerWithConfig(TestContext, "tls_1222_verify.conf"))
+            using (NATSServer srv = util.CreateServerWithConfig("tls_1222_verify.conf"))
             {
                 Options opts = ConnectionFactory.GetDefaultOptions();
                 opts.Secure = true;
@@ -122,8 +102,7 @@ namespace NATSUnitTests
                 // openssl pkcs12 -export -out client.pfx 
                 //    -inkey client-key.pem -in client-cert.pem
                 X509Certificate2 cert = new X509Certificate2(
-                    UnitTestUtilities.GetFullCertificatePath(
-                        TestContext, "client.pfx"), "password");
+                    UnitTestUtilities.GetFullCertificatePath("client.pfx"), "password");
 
                 opts.AddCertificate(cert);
 
@@ -134,16 +113,16 @@ namespace NATSUnitTests
                         c.Publish("foo", null);
                         c.Flush();
                         Msg m = s.NextMessage();
-                        System.Console.WriteLine("Received msg over TLS conn.");
+                        Console.WriteLine("Received msg over TLS conn.");
                     }
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTlsFailWithCert()
         {
-            using (NATSServer srv = util.CreateServerWithConfig(TestContext, "tls_1222_verify.conf"))
+            using (NATSServer srv = util.CreateServerWithConfig("tls_1222_verify.conf"))
             {
                 Options opts = ConnectionFactory.GetDefaultOptions();
                 opts.Secure = true;
@@ -152,8 +131,7 @@ namespace NATSUnitTests
 
                 // this will fail, because it's not complete - missing the private
                 // key.
-                opts.AddCertificate(UnitTestUtilities.GetFullCertificatePath(
-                        TestContext, "client-cert.pem"));
+                opts.AddCertificate(UnitTestUtilities.GetFullCertificatePath("client-cert.pem"));
 
                 try
                 {
@@ -161,7 +139,7 @@ namespace NATSUnitTests
                 }
                 catch (NATSException nae)     
                 {
-                    System.Console.WriteLine("Caught expected exception: " + nae.Message);
+                    Console.WriteLine("Caught expected exception: " + nae.Message);
                     return;
                 }
 
@@ -169,10 +147,10 @@ namespace NATSUnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTlsFailWithBadAuth()
         {
-            using (NATSServer srv = util.CreateServerWithConfig(TestContext, "tls_1222_user.conf"))
+            using (NATSServer srv = util.CreateServerWithConfig("tls_1222_user.conf"))
             {
                 Options opts = ConnectionFactory.GetDefaultOptions();
                 opts.Secure = true;
@@ -181,8 +159,7 @@ namespace NATSUnitTests
 
                 // this will fail, because it's not complete - missing the private
                 // key.
-                opts.AddCertificate(UnitTestUtilities.GetFullCertificatePath(
-                        TestContext, "client-cert.pem"));
+                opts.AddCertificate(UnitTestUtilities.GetFullCertificatePath("client-cert.pem"));
 
                 try
                 {
@@ -190,8 +167,8 @@ namespace NATSUnitTests
                 }
                 catch (NATSException nae)
                 {
-                    System.Console.WriteLine("Caught expected exception: " + nae.Message);
-                    System.Console.WriteLine("Exception output:" + nae);
+                    Console.WriteLine("Caught expected exception: " + nae.Message);
+                    Console.WriteLine("Exception output:" + nae);
                     return;
                 }
 
@@ -199,10 +176,10 @@ namespace NATSUnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTlsSuccessSecureConnect()
         {
-            using (NATSServer srv = util.CreateServerWithConfig(TestContext, "tls_1222.conf"))
+            using (NATSServer srv = util.CreateServerWithConfig("tls_1222.conf"))
             {
                 // we can't call create secure connection w/ the certs setup as they are
                 // so we'll override the 
@@ -218,21 +195,21 @@ namespace NATSUnitTests
                         c.Publish("foo", null);
                         c.Flush();
                         Msg m = s.NextMessage();
-                        System.Console.WriteLine("Received msg over TLS conn.");
+                        Console.WriteLine("Received msg over TLS conn.");
                     }
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTlsReconnect()
         {
             ConditionalObj reconnectedObj = new ConditionalObj();
 
-            using (NATSServer srv = util.CreateServerWithConfig(TestContext, "tls_1222.conf"),
-                   srv2 = util.CreateServerWithConfig(TestContext, "tls_1224.conf"))
+            using (NATSServer srv = util.CreateServerWithConfig("tls_1222.conf"),
+                   srv2 = util.CreateServerWithConfig("tls_1224.conf"))
             {
-                System.Threading.Thread.Sleep(1000);
+                Thread.Sleep(1000);
 
                 Options opts = ConnectionFactory.GetDefaultOptions();
                 opts.Secure = true;
@@ -253,7 +230,7 @@ namespace NATSUnitTests
                         c.Publish("foo", null);
                         c.Flush();
                         s.NextMessage();
-                        System.Console.WriteLine("Received msg over TLS conn.");
+                        Console.WriteLine("Received msg over TLS conn.");
 
                         // shutdown the server
                         srv.Shutdown();
@@ -264,7 +241,7 @@ namespace NATSUnitTests
                         c.Publish("foo", null);
                         c.Flush();
                         s.NextMessage();
-                        System.Console.WriteLine("Received msg over TLS conn.");
+                        Console.WriteLine("Received msg over TLS conn.");
                     }
                 }
             }
@@ -272,14 +249,14 @@ namespace NATSUnitTests
 
         // Tests if reconnection can still occur after a user authorization failure
         // under TLS.
-        [TestMethod]
+        [Fact]
         public void TestTlsReconnectAuthTimeout()
         {
             ConditionalObj obj = new ConditionalObj();
 
-            using (NATSServer s1 = util.CreateServerWithConfig(TestContext, "auth_tls_1222.conf"),
-                              s2 = util.CreateServerWithConfig(TestContext, "auth_tls_1223_timeout.conf"),
-                              s3 = util.CreateServerWithConfig(TestContext, "auth_tls_1224.conf"))
+            using (NATSServer s1 = util.CreateServerWithConfig("auth_tls_1222.conf"),
+                              s2 = util.CreateServerWithConfig("auth_tls_1223_timeout.conf"),
+                              s3 = util.CreateServerWithConfig("auth_tls_1224.conf"))
             {
 
                 Options opts = ConnectionFactory.GetDefaultOptions();
@@ -294,7 +271,7 @@ namespace NATSUnitTests
 
                 opts.ReconnectedEventHandler += (sender, args) =>
                 {
-                    System.Console.WriteLine("Reconnected");
+                    Console.WriteLine("Reconnected");
                     obj.notify();
                 };
 
@@ -308,13 +285,13 @@ namespace NATSUnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTlsReconnectAuthTimeoutLateClose()
         {
             ConditionalObj obj = new ConditionalObj();
 
-            using (NATSServer s1 = util.CreateServerWithConfig(TestContext, "auth_tls_1222.conf"),
-                              s2 = util.CreateServerWithConfig(TestContext, "auth_tls_1224.conf"))
+            using (NATSServer s1 = util.CreateServerWithConfig("auth_tls_1222.conf"),
+                              s2 = util.CreateServerWithConfig("auth_tls_1224.conf"))
             {
 
                 Options opts = ConnectionFactory.GetDefaultOptions();
@@ -337,12 +314,14 @@ namespace NATSUnitTests
                 // this is done at the parser level so that parsing is also tested,
                 // therefore it needs reflection since Parser is an internal type.
                 Type parserType = typeof(Connection).Assembly.GetType("NATS.Client.Parser");
-                Assert.IsNotNull(parserType, "Failed to find NATS.Client.Parser");
+                Assert.NotNull(parserType);
+
                 BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
                 object parser = Activator.CreateInstance(parserType, flags, null, new object[] { c }, null);
-                Assert.IsNotNull(parser, "Failed to instanciate a NATS.Client.Parser");
+                Assert.NotNull(parser);
+
                 MethodInfo parseMethod = parserType.GetMethod("parse", flags);
-                Assert.IsNotNull(parseMethod, "Failed to find method parse in NATS.Client.Parser");
+                Assert.NotNull(parseMethod);
 
                 byte[] bytes = "-ERR 'Authorization Timeout'\r\n".ToCharArray().Select(ch => (byte)ch).ToArray();
                 parseMethod.Invoke(parser, new object[] { bytes, bytes.Length });

--- a/NATSUnitTests/UnitTestUtilities.cs
+++ b/NATSUnitTests/UnitTestUtilities.cs
@@ -137,7 +137,9 @@ namespace NATSUnitTests
 
         internal static string GetConfigDir()
         {
-            var runningDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var codeBaseUrl = new Uri(Assembly.GetExecutingAssembly().CodeBase);
+            var codeBasePath = Uri.UnescapeDataString(codeBaseUrl.AbsolutePath);
+            var runningDirectory = Path.GetDirectoryName(codeBasePath);
             return Path.Combine(runningDirectory, "config");
         }
 

--- a/NATSUnitTests/packages.config
+++ b/NATSUnitTests/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/NATSUnitTests/packages.config
+++ b/NATSUnitTests/packages.config
@@ -6,4 +6,5 @@
   <package id="xunit.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
## Goal of the pull request

Convert tests currently running on MSTests to XUnit to remove dependency on Visual Studio. As discussed in issue #62 
## What is needed
- [x] Convert MSTest project to regular class library since the .csproj itself fiddle with MSTest
- [x] Remove MSTest and add XUnit
- [x] Convert all Assert nomenclature to the XUnit one
- [x] Replace all  `if` checks with associated `Assert.Fail` in code since it does not exist in XUnit
- [x] Remove all `TestContext` in code since it does not exist in XUnit
- [x] Validate that all tests are still passing
