### PR TITLE
Remove interpolated strings

### DIFF
--- a/NATSUnitTests/UnitTestBasic.cs
+++ b/NATSUnitTests/UnitTestBasic.cs
@@ -36,7 +36,7 @@ namespace NATSUnitTests
 
             string u = c.ConnectedUrl;
 
-            Assert.False(string.IsNullOrWhiteSpace(u), $"Invalid connected url {u}.");
+            Assert.False(string.IsNullOrWhiteSpace(u), string.Format("Invalid connected url {0}.", u));
 
             Assert.Equal(Defaults.Url, u);
 
@@ -249,7 +249,7 @@ namespace NATSUnitTests
 
                     Assert.Equal(total, r1 + r2);
 
-                    Assert.False(Math.Abs(r1 - r2) > total * .15, $"Too much variance between {r1} and {r2}");
+                    Assert.False(Math.Abs(r1 - r2) > total * .15, string.Format("Too much variance between {0} and {1}", r1, r2));
                 }
             }
         }

--- a/NATSUnitTests/UnitTestCluster.cs
+++ b/NATSUnitTests/UnitTestCluster.cs
@@ -260,7 +260,7 @@ namespace NATSUnitTests
             int delta = Math.Abs(s2Count - s3Count);
             int range = numClients / 30;
 
-            Assert.False(delta > range, $"Connected clients to servers out of range: {delta}/{range}");
+            Assert.False(delta > range, string.Format("Connected clients to servers out of range: {0}/{0}", delta, range));
 
         }
 

--- a/NATSUnitTests/UnitTestNUID.cs
+++ b/NATSUnitTests/UnitTestNUID.cs
@@ -95,7 +95,7 @@ namespace NATSUnitTests
             for (int i = 0; i < count; i++)
             {
                 String n = NUID.NextGlobal;
-                Assert.False(m.ContainsKey(n), $"Duplicate NUID found: {n}");
+                Assert.False(m.ContainsKey(n), string.Format("Duplicate NUID found: {0}", n));
 
                 m.Add(n, true);
             }

--- a/NATSUnitTests/UnitTestReconnect.cs
+++ b/NATSUnitTests/UnitTestReconnect.cs
@@ -287,7 +287,7 @@ namespace NATSUnitTests
                 for (int i = 0; i < numSent; i++)
                 {
                     Assert.True(results.ContainsKey(i),
-                        $"Received incorrect number of messages, {results[i]} for seq: {i}");
+                        string.Format("Received incorrect number of messages, {0} for seq: {1}", results[i], i));
                 }
 
                 results.Clear();
@@ -393,7 +393,7 @@ namespace NATSUnitTests
                 s1.Shutdown();
 
                 Thread.Sleep(100);
-                Assert.False(c.IsClosed(), $"Invalid state, expecting not closed, received: {c.State}");
+                Assert.False(c.IsClosed(), string.Format("Invalid state, expecting not closed, received: {0}", c.State));
                 
                 using (NATSServer s2 = utils.CreateServerOnPort(22222))
                 {

--- a/NATSUnitTests/UnitTestSub.cs
+++ b/NATSUnitTests/UnitTestSub.cs
@@ -228,7 +228,8 @@ namespace NATSUnitTests
                     subCond.notify();
 
                     Assert.False(sw.ElapsedMilliseconds >= flushTimeout,
-                        $"elapsed ({sw.ElapsedMilliseconds}) > timeout ({flushTimeout})");
+                        string.Format("elapsed ({0}) > timeout ({1})",
+                            sw.ElapsedMilliseconds, flushTimeout));
 
                 }
             }


### PR DESCRIPTION
No functional changes; just not quite ready to require C# 6 features in the source code to support legacy users.
