### PR TITLE
CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: csharp
+solution: NATS.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ install:
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
   - appveyor DownloadFile https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-windows-386.zip
   - 7z e gnatsd-v0.8.1-windows-386.zip gnatsd.exe -r -oc:\projects\csnats\build
-  - `set PATH=%PATH%;C:\projects\csnats\build`
+  - cmd: set PATH=%PATH%;C:\projects\csnats\build
   - ps: dir -recurse
 before_build:
   - nuget restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+install:
+  - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+  - ps: (new-object net.webclient).DownloadFile('https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-windows-386.zip', 'gnatsd.zip')
 before_build:
   - nuget restore
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ install:
   - appveyor DownloadFile https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-windows-386.zip
   - 7z e gnatsd-v0.8.1-windows-386.zip gnatsd.exe -r -oc:\projects\csnats\build
   - cmd: set PATH=%PATH%;C:\projects\csnats\build
-  - ps: dir -recurse
 before_build:
   - nuget restore
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,10 @@
 install:
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
   - appveyor DownloadFile https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-windows-386.zip
-  - 7z e gnatsd-v0.8.1-windows-386.zip gnatsd.exe -r
-  - ps: dir
+  
+  - 7z e gnatsd-v0.8.1-windows-386.zip gnatsd.exe -r -oc:\projects\csnats\build
+  - `set PATH=%PATH%;C:\projects\csnats\build`
+  - ps: dir -recurse
 before_build:
   - nuget restore
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 install:
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
   - appveyor DownloadFile https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-windows-386.zip
-  - 7z e gnatsd-v0.8.1-windows-386.zip
+  - 7z e gnatsd-v0.8.1-windows-386.zip -s
   - ps: dir
 before_build:
   - nuget restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 install:
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-  - ps: (new-object net.webclient).DownloadFile('https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-windows-386.zip', 'gnatsd.zip')
+  - appveyor DownloadFile https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-windows-386.zip
   - ps: dir
 before_build:
   - nuget

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 install:
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
   - appveyor DownloadFile https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-windows-386.zip
+  - 7z e gnatsd-v0.8.1-windows-386.zip
   - ps: dir
 before_build:
-  - nuget
   - nuget restore
 build:
   project: NATS.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 install:
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
   - ps: (new-object net.webclient).DownloadFile('https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-windows-386.zip', 'gnatsd.zip')
+  - ps: dir
 before_build:
+  - nuget
   - nuget restore
 build:
   project: NATS.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,4 @@
+before_build:
+  - nuget restore
+build:
+  project: NATS.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 install:
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
   - appveyor DownloadFile https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-windows-386.zip
-  - 7z e gnatsd-v0.8.1-windows-386.zip -s
+  - 7z e gnatsd-v0.8.1-windows-386.zip gnatsd.exe -r
   - ps: dir
 before_build:
   - nuget restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 install:
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
   - appveyor DownloadFile https://github.com/nats-io/gnatsd/releases/download/v0.8.1/gnatsd-v0.8.1-windows-386.zip
-  
   - 7z e gnatsd-v0.8.1-windows-386.zip gnatsd.exe -r -oc:\projects\csnats\build
   - `set PATH=%PATH%;C:\projects\csnats\build`
   - ps: dir -recurse


### PR DESCRIPTION
Hi @derekcollison 

I added basic support for CI builds on AppVeyor and Travis-CI. 

For AppVeyor, I created the configuration files `appveyor.yml` with everything needed to build the solution and run all unit tests. The scripts download the latest version of gnatsd.exe from the GitHub repo so that the tests can run. The solution builds correctly and tests results are available online, you can see it here: [build](https://ci.appveyor.com/project/cstlaurent/csnats) and here [tests](https://ci.appveyor.com/project/cstlaurent/csnats/build/tests). There seem to be some flaky tests that sometimes fail, depending on the order they runs I imagine...

On the other hand, for Travis-CI, I added a basic config file but it looks like the solution does not build on a mono target with some errors related to encryption, so I left it at that: 
![image](https://cloud.githubusercontent.com/assets/213276/17075581/c8b481c2-5065-11e6-8774-92e27cbd7482.png)

You can see my Travis Build [here](https://travis-ci.org/cstlaurent/csnats)

I think the build script is a bit hacky right now and a lot more could be added but I think it's a pretty good start!

All you would have to do now is to create accounts on Travis and AppVeyor (if you don't have one already), enable builds on the csnats repo and everything should work properly.
