### PR TITLE
Fix potential memory leaks when disposing a connection

### DIFF
--- a/NATS/Channel.cs
+++ b/NATS/Channel.cs
@@ -113,6 +113,8 @@ namespace NATS.Client
             finished = true;
             Monitor.Pulse(qLock);
 
+            q.Clear();
+
             Monitor.Exit(qLock);
         }
 


### PR DESCRIPTION
When a connection is disposed of immediately after creation, orphaned objects can maintain references to the connection.  Under typical operation, this does not occur as connections have time to fully initialize.

The ping timer and callback scheduler maintained references to connection objects in this scenario.

Resolves #93
