### PR TITLE
Support large numbers of subscribers on a connection

### DIFF
--- a/NATS.Client/Channel.cs
+++ b/NATS.Client/Channel.cs
@@ -2,15 +2,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace NATS.Client
 {
-    // This channel class really a blocking queue, is named the way it is
+    // This channel class, really a blocking queue, is named the way it is
     // so the code more closely reads with GO.  We implement our own channels 
     // to be lightweight and performant - other concurrent classes do the
     // task but are more heavyweight that what we want.

--- a/NATS.Client/Options.cs
+++ b/NATS.Client/Options.cs
@@ -335,7 +335,8 @@ namespace NATS.Client
         /// <summary>
         /// Sets or gets number of long running tasks to deliver messages
         /// to asynchronous subscribers.  The default is 0 indicating each
-        /// subscriber has its own channel and task created to deliver messages.
+        /// asynchronous subscriber has its own channel and task created to 
+        /// deliver messages.
         /// </summary>
         /// <remarks>
         /// The default where each subscriber has a delivery task is very 
@@ -347,7 +348,7 @@ namespace NATS.Client
         /// Delivery order by subscriber is still guaranteed.  The shared message
         /// processing channels are still each bounded by the SubChannelLength 
         /// option.  Note, slow subscriber errors will flag the last subscriber 
-        /// processed in the taks, which may not actually be the slowest subscriber.
+        /// processed in the tasks, which may not actually be the slowest subscriber.
         /// </remarks>
         public int SubscriberDeliveryTaskCount
         {

--- a/NATS.Client/Options.cs
+++ b/NATS.Client/Options.cs
@@ -54,7 +54,8 @@ namespace NATS.Client
 
         internal int maxPingsOut = Defaults.MaxPingOut;
 
-        internal int subChanLen = 40000;
+        internal int subChanLen = 65536;
+        internal int subscriberDeliveryTaskCount = 0;
 
         internal string user;
         internal string password;
@@ -89,6 +90,7 @@ namespace NATS.Client
             password = o.password;
             token = o.token;
             verbose = o.verbose;
+            subscriberDeliveryTaskCount = o.subscriberDeliveryTaskCount;
             
             if (o.servers != null)
             {
@@ -329,6 +331,40 @@ namespace NATS.Client
         /// </remarks>
         public RemoteCertificateValidationCallback TLSRemoteCertificationValidationCallback;
 
+
+        /// <summary>
+        /// Sets or gets number of long running tasks to deliver messages
+        /// to asynchronous subscribers.  The default is 0 indicating each
+        /// subscriber has its own channel and task created to deliver messages.
+        /// </summary>
+        /// <remarks>
+        /// The default where each subscriber has a delivery task is very 
+        /// performant, but does not scale well when large numbers of
+        /// subscribers are required in an application.  Setting this value
+        /// will limit the number of subscriber channels to the specified number
+        /// of long running tasks.  These tasks will process messages for ALL
+        /// asynchronous subscribers rather than one task for each subscriber.  
+        /// Delivery order by subscriber is still guaranteed.  The shared message
+        /// processing channels are still each bounded by the SubChannelLength 
+        /// option.  Note, slow subscriber errors will flag the last subscriber 
+        /// processed in the taks, which may not actually be the slowest subscriber.
+        /// </remarks>
+        public int SubscriberDeliveryTaskCount
+        {
+            get
+            {
+                return subscriberDeliveryTaskCount;
+            }
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException("SubscriberDeliveryTaskCount must be 0 or greater.");
+                }
+                subscriberDeliveryTaskCount = value;
+            }
+        }
+
         private void appendEventHandler(StringBuilder sb, String name, Delegate eh)
         {
             if (eh != null)
@@ -363,6 +399,7 @@ namespace NATS.Client
             sb.AppendFormat("Secure={0};", Secure);
             sb.AppendFormat("User={0};", User);
             sb.AppendFormat("Token={0};", Token);
+            sb.AppendFormat("SubscriberDeliveryTaskCount={0};", SubscriberDeliveryTaskCount);
 
             if (Servers == null)
             {

--- a/NATS.Client/SyncSub.cs
+++ b/NATS.Client/SyncSub.cs
@@ -12,7 +12,10 @@ namespace NATS.Client
     public sealed class SyncSubscription : Subscription, ISyncSubscription, ISubscription 
     {
         internal SyncSubscription(Connection conn, string subject, string queue)
-            : base(conn, subject, queue) { }
+            : base(conn, subject, queue)
+        {
+            mch = new Channel<Msg>();
+        }
 
         public Msg NextMessage()
         {


### PR DESCRIPTION
Using one task and channel per subscriber to handle message events is very performant, but comes at the cost of resource usage, limiting the number of asynchronous subscribers that can be created in an application.

This change adds subscriber channel and task pooling to share resources for all asynchronous subscribers.  A new option, `SubscriberDeliveryTaskCount`, sets the number of long running tasks to deliver messages to asynchronous subscribers.  The default is `0` indicating each asynchronous subscriber has its own channel and task created to deliver messages.  Setting this value to a positive integer will cause all asynchronous subscribers on a connection to share channels, and the long running tasks that process messages.  Delivery order by subscriber is still guaranteed - a subscriber will always use the same channel and be processed by the same task.   The shared message processing channels are still each bounded by the SubChannelLength option.  Note, slow subscriber errors will flag the last subscriber processed in the task, which may not actually be the slowest subscriber.

This PR includes:
- The new parameter, `SubscriberDeliveryTaskCount`
- Supporting code to create and share channels and tasks across async subscribers.
- Tests

Resolves #122 
Resolved #113
