### PR TITLE
Test cleanup and fix flappers

### DIFF
--- a/NATSUnitTests/UnitTestAuth.cs
+++ b/NATSUnitTests/UnitTestAuth.cs
@@ -24,7 +24,7 @@ namespace NATSUnitTests
             try
             {
                 hitDisconnect = 0;
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = util.DefaultTestOptions;
                 opts.Url = url;
                 opts.DisconnectedEventHandler += handleDisconnect;
                 IConnection c = new ConnectionFactory().CreateConnection(url);
@@ -92,7 +92,7 @@ namespace NATSUnitTests
                               s3 = util.CreateServerWithConfig("auth_1224.conf"))
             {
 
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = util.DefaultTestOptions;
 
                 opts.Servers = new string[]{
                     "nats://username:password@localhost:1222",
@@ -126,7 +126,7 @@ namespace NATSUnitTests
                               s2 = util.CreateServerWithConfig("auth_1224.conf"))
             {
 
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = util.DefaultTestOptions;
 
                 opts.Servers = new string[]{
                     "nats://username:password@localhost:1222",

--- a/NATSUnitTests/UnitTestAuth.cs
+++ b/NATSUnitTests/UnitTestAuth.cs
@@ -85,7 +85,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestReconnectAuthTimeout()
         {
-            ConditionalObj obj = new ConditionalObj();
+            AutoResetEvent ev  = new AutoResetEvent(false);
 
             using (NATSServer s1 = util.CreateServerWithConfig("auth_1222.conf"),
                               s2 = util.CreateServerWithConfig("auth_1223_timeout.conf"),
@@ -102,7 +102,7 @@ namespace NATSUnitTests
 
                 opts.ReconnectedEventHandler += (sender, args) =>
                 {
-                    obj.notify();
+                    ev.Set();
                 };
 
                 IConnection c = new ConnectionFactory().CreateConnection(opts);
@@ -112,7 +112,7 @@ namespace NATSUnitTests
                 // This should fail over to S2 where an authorization timeout occurs
                 // then successfully reconnect to S3.
 
-                obj.wait(20000);
+                Assert.True(ev.WaitOne(20000));
             }
         }
 
@@ -120,7 +120,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestReconnectAuthTimeoutLateClose()
         {
-            ConditionalObj obj = new ConditionalObj();
+            AutoResetEvent ev = new AutoResetEvent(false);
 
             using (NATSServer s1 = util.CreateServerWithConfig("auth_1222.conf"),
                               s2 = util.CreateServerWithConfig("auth_1224.conf"))
@@ -135,7 +135,7 @@ namespace NATSUnitTests
 
                 opts.ReconnectedEventHandler += (sender, args) =>
                 {
-                    obj.notify();
+                    ev.Set();
                 };
 
                 IConnection c = new ConnectionFactory().CreateConnection(opts);
@@ -161,7 +161,7 @@ namespace NATSUnitTests
                 s1.Shutdown();
 
                 // Wait for a reconnect.
-                obj.wait(20000);
+                Assert.True(ev.WaitOne(20000));
             }
         }
 #endif

--- a/NATSUnitTests/UnitTestBasic.cs
+++ b/NATSUnitTests/UnitTestBasic.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using Xunit;
 using System.Collections.Generic;
 
+
 namespace NATSUnitTests
 {
     /// <summary>
@@ -33,7 +34,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestConnectedServer()
         {
-            IConnection c = new ConnectionFactory().CreateConnection();
+            IConnection c = utils.DefaultTestConnection;
 
             string u = c.ConnectedUrl;
 
@@ -50,7 +51,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestMultipleClose()
         {
-            IConnection c = new ConnectionFactory().CreateConnection();
+            IConnection c = utils.DefaultTestConnection;
 
             Task[] tasks = new Task[10];
 
@@ -67,7 +68,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestBadOptionTimeoutConnect()
         {
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
 
             Assert.ThrowsAny<Exception>(() => opts.Timeout = -1);
         }
@@ -75,7 +76,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestSimplePublish()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 c.Publish("foo", Encoding.UTF8.GetBytes("Hello World!"));
             }
@@ -84,7 +85,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestSimplePublishNoData()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 c.Publish("foo", null);
             }
@@ -136,7 +137,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestAsyncSubscribe()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                 {
@@ -172,7 +173,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestSyncSubscribe()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (ISyncSubscription s = c.SubscribeSync("foo"))
                 {
@@ -187,7 +188,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestPubWithReply()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (ISyncSubscription s = c.SubscribeSync("foo"))
                 {
@@ -202,7 +203,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestFlush()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (ISyncSubscription s = c.SubscribeSync("foo"))
                 {
@@ -215,7 +216,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestQueueSubscriber()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (ISyncSubscription s1 = c.SubscribeSync("foo", "bar"),
                                          s2 = c.SubscribeSync("foo", "bar"))
@@ -255,7 +256,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestReplyArg()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                 {
@@ -288,7 +289,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestSyncReplyArg()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (ISyncSubscription s = c.SubscribeSync("foo"))
                 {
@@ -308,7 +309,7 @@ namespace NATSUnitTests
             int count = 0;
             int max = 20;
 
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                 {
@@ -354,7 +355,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestDoubleUnsubscribe()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (ISyncSubscription s = c.SubscribeSync("foo"))
                 {
@@ -368,7 +369,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestRequestTimeout()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 Assert.ThrowsAny<Exception>(() => c.Request("foo", null, 500));
             }
@@ -377,7 +378,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestRequest()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                 {
@@ -402,7 +403,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestRequestNoBody()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                 {
@@ -424,7 +425,7 @@ namespace NATSUnitTests
 
         public async void testRequestAsync()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 byte[] response = Encoding.UTF8.GetBytes("I will help you.");
 
@@ -466,7 +467,7 @@ namespace NATSUnitTests
 
         public async void testRequestAsyncCancellation()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 int responseDelay = 0;
 
@@ -583,8 +584,8 @@ namespace NATSUnitTests
 
             ThreadPool.SetMinThreads(300, 300);
 
-            using (IConnection c1 = new ConnectionFactory().CreateConnection(),
-                               c2 = new ConnectionFactory().CreateConnection())
+            using (IConnection c1 = utils.DefaultTestConnection,
+                               c2 = utils.DefaultTestConnection)
             {
                 using (IAsyncSubscription s = c1.SubscribeAsync("foo", (sender, args) =>
                 {
@@ -654,8 +655,8 @@ namespace NATSUnitTests
             Stopwatch sw = new Stopwatch();
             byte[] response = Encoding.UTF8.GetBytes("reply");
 
-            using (IConnection c1 = new ConnectionFactory().CreateConnection(),
-                               c2 = new ConnectionFactory().CreateConnection())
+            using (IConnection c1 = utils.DefaultTestConnection,
+                               c2 = utils.DefaultTestConnection)
             {
                 // Try parallel requests and check the performance.
                 using (IAsyncSubscription s = c1.SubscribeAsync("foo", (sender, args) =>
@@ -710,7 +711,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestFlushInHandler()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                 {
@@ -740,7 +741,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestReleaseFlush()
         {
-            IConnection c = new ConnectionFactory().CreateConnection();
+            IConnection c = utils.DefaultTestConnection;
 
             for (int i = 0; i < 1000; i++)
             {
@@ -754,7 +755,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestCloseAndDispose()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 c.Close();
             }
@@ -763,7 +764,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestInbox()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 string inbox = c.NewInbox();
                 Assert.False(string.IsNullOrWhiteSpace(inbox));
@@ -774,7 +775,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestStats()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 byte[] data = Encoding.UTF8.GetBytes("The quick brown fox jumped over the lazy dog");
                 int iter = 10;
@@ -813,7 +814,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestRaceSafeStats()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
 
                 new Task(() => { c.Publish("foo", null); }).Start();
@@ -827,7 +828,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestBadSubject()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 bool exThrown = false;
                 try
@@ -846,7 +847,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestLargeMessage()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 int msgSize = 51200;
                 byte[] msg = new byte[msgSize];
@@ -885,7 +886,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestSendAndRecv()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                 {
@@ -916,7 +917,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestLargeSubjectAndReply()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 String subject = "";
                 for (int i = 0; i < 1024; i++)
@@ -959,7 +960,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestAsyncSubHandlerAPI()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 int received = 0;
 
@@ -1021,7 +1022,7 @@ namespace NATSUnitTests
                 // let the server cluster form
                 Thread.Sleep(1000);
 
-                var opts = ConnectionFactory.GetDefaultOptions();
+                var opts = utils.DefaultTestOptions;
                 opts.Url = "nats://127.0.0.1:4223";
 
                 var c = new ConnectionFactory().CreateConnection(opts);
@@ -1037,7 +1038,7 @@ namespace NATSUnitTests
         public void TestAsyncInfoProtocolUpdate()
         {
             AutoResetEvent evReconnect = new AutoResetEvent(false);
-            var opts = ConnectionFactory.GetDefaultOptions();
+            var opts = utils.DefaultTestOptions;
             opts.Url = "nats://127.0.0.1:4223";
             string newUrl = null;
 
@@ -1104,7 +1105,7 @@ namespace NATSUnitTests
                 "nats://localhost:4"
             };
 
-            var opts = ConnectionFactory.GetDefaultOptions();
+            var opts = utils.DefaultTestOptions;
             opts.Servers = serverList;
             opts.NoRandomize = true;
 

--- a/NATSUnitTests/UnitTestBasic.cs
+++ b/NATSUnitTests/UnitTestBasic.cs
@@ -21,7 +21,7 @@ namespace NATSUnitTests
         public TestBasic()
         {
             UnitTestUtilities.CleanupExistingServers();
-            utils.StartDefaultServerAndDelay();
+            utils.StartDefaultServerAndVerify();
         }
 
         public void Dispose()

--- a/NATSUnitTests/UnitTestBasic.cs
+++ b/NATSUnitTests/UnitTestBasic.cs
@@ -15,54 +15,48 @@ namespace NATSUnitTests
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    public class TestBasic : IDisposable
+    public class TestBasic
     {
         UnitTestUtilities utils = new UnitTestUtilities();
-
-        public TestBasic()
-        {
-            UnitTestUtilities.CleanupExistingServers();
-            utils.StartDefaultServerAndVerify();
-        }
-
-        public void Dispose()
-        {
-            utils.StopDefaultServer();
-        }
-
 
         [Fact]
         public void TestConnectedServer()
         {
-            IConnection c = utils.DefaultTestConnection;
+            using (new NATSServer())
+            {
+                IConnection c = utils.DefaultTestConnection;
 
-            string u = c.ConnectedUrl;
+                string u = c.ConnectedUrl;
 
-            Assert.False(string.IsNullOrWhiteSpace(u), string.Format("Invalid connected url {0}.", u));
+                Assert.False(string.IsNullOrWhiteSpace(u), string.Format("Invalid connected url {0}.", u));
 
-            Assert.Equal(Defaults.Url, u);
+                Assert.Equal(Defaults.Url, u);
 
-            c.Close();
-            u = c.ConnectedUrl;
+                c.Close();
+                u = c.ConnectedUrl;
 
-            Assert.Null(u);
+                Assert.Null(u);
+            }
         }
 
         [Fact]
         public void TestMultipleClose()
         {
-            IConnection c = utils.DefaultTestConnection;
-
-            Task[] tasks = new Task[10];
-
-            for (int i = 0; i < 10; i++)
+            using (new NATSServer())
             {
+                IConnection c = utils.DefaultTestConnection;
 
-                tasks[i] = new Task(() => { c.Close(); });
-                tasks[i].Start();
+                Task[] tasks = new Task[10];
+
+                for (int i = 0; i < 10; i++)
+                {
+
+                    tasks[i] = new Task(() => { c.Close(); });
+                    tasks[i].Start();
+                }
+
+                Task.WaitAll(tasks);
             }
-
-            Task.WaitAll(tasks);
         }
 
         [Fact]
@@ -76,22 +70,26 @@ namespace NATSUnitTests
         [Fact]
         public void TestSimplePublish()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                c.Publish("foo", Encoding.UTF8.GetBytes("Hello World!"));
+                using (IConnection c = utils.DefaultTestConnection)
+                {
+                    c.Publish("foo", Encoding.UTF8.GetBytes("Hello World!"));
+                }
             }
         }
 
         [Fact]
         public void TestSimplePublishNoData()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                c.Publish("foo", null);
+                using (IConnection c = utils.DefaultTestConnection)
+                {
+                    c.Publish("foo", null);
+                }
             }
         }
-
-
 
         private bool compare(byte[] p1, byte[] p2)
         {
@@ -137,23 +135,26 @@ namespace NATSUnitTests
         [Fact]
         public void TestAsyncSubscribe()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (IAsyncSubscription s = c.SubscribeAsync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    asyncSub = s;
-                    s.MessageHandler += CheckReceivedAndValidHandler;
-                    s.Start();
-
-                    lock (mu)
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                     {
-                        received = false;
-                        c.Publish("foo", omsg);
-                        c.Flush();
-                        Monitor.Wait(mu, 30000);
-                    }
+                        asyncSub = s;
+                        s.MessageHandler += CheckReceivedAndValidHandler;
+                        s.Start();
 
-                    Assert.True(received, "Did not receive message.");
+                        lock (mu)
+                        {
+                            received = false;
+                            c.Publish("foo", omsg);
+                            c.Flush();
+                            Monitor.Wait(mu, 30000);
+                        }
+
+                        Assert.True(received, "Did not receive message.");
+                    }
                 }
             }
         }
@@ -173,14 +174,17 @@ namespace NATSUnitTests
         [Fact]
         public void TestSyncSubscribe()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (ISyncSubscription s = c.SubscribeSync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    c.Publish("foo", omsg);
-                    Msg m = s.NextMessage(1000);
+                    using (ISyncSubscription s = c.SubscribeSync("foo"))
+                    {
+                        c.Publish("foo", omsg);
+                        Msg m = s.NextMessage(1000);
 
-                    Assert.True(compare(omsg, m), "Messages are not equal.");
+                        Assert.True(compare(omsg, m), "Messages are not equal.");
+                    }
                 }
             }
         }
@@ -188,14 +192,17 @@ namespace NATSUnitTests
         [Fact]
         public void TestPubWithReply()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (ISyncSubscription s = c.SubscribeSync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    c.Publish("foo", "reply", omsg);
-                    Msg m = s.NextMessage(1000);
+                    using (ISyncSubscription s = c.SubscribeSync("foo"))
+                    {
+                        c.Publish("foo", "reply", omsg);
+                        Msg m = s.NextMessage(1000);
 
-                    Assert.True(compare(omsg, m), "Messages are not equal.");
+                        Assert.True(compare(omsg, m), "Messages are not equal.");
+                    }
                 }
             }
         }
@@ -203,12 +210,15 @@ namespace NATSUnitTests
         [Fact]
         public void TestFlush()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (ISyncSubscription s = c.SubscribeSync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    c.Publish("foo", "reply", omsg);
-                    c.Flush();
+                    using (ISyncSubscription s = c.SubscribeSync("foo"))
+                    {
+                        c.Publish("foo", "reply", omsg);
+                        c.Flush();
+                    }
                 }
             }
         }
@@ -216,39 +226,42 @@ namespace NATSUnitTests
         [Fact]
         public void TestQueueSubscriber()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (ISyncSubscription s1 = c.SubscribeSync("foo", "bar"),
-                                         s2 = c.SubscribeSync("foo", "bar"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    c.Publish("foo", omsg);
-                    c.Flush(1000);
-
-                    Assert.Equal(1, s1.QueuedMessageCount + s2.QueuedMessageCount);
-
-                    // Drain the messages.
-                    try { s1.NextMessage(100); }
-                    catch (NATSTimeoutException) { }
-
-                    try { s2.NextMessage(100); }
-                    catch (NATSTimeoutException) { }
-
-                    int total = 1000;
-
-                    for (int i = 0; i < 1000; i++)
+                    using (ISyncSubscription s1 = c.SubscribeSync("foo", "bar"),
+                                             s2 = c.SubscribeSync("foo", "bar"))
                     {
                         c.Publish("foo", omsg);
+                        c.Flush(1000);
+
+                        Assert.Equal(1, s1.QueuedMessageCount + s2.QueuedMessageCount);
+
+                        // Drain the messages.
+                        try { s1.NextMessage(100); }
+                        catch (NATSTimeoutException) { }
+
+                        try { s2.NextMessage(100); }
+                        catch (NATSTimeoutException) { }
+
+                        int total = 1000;
+
+                        for (int i = 0; i < 1000; i++)
+                        {
+                            c.Publish("foo", omsg);
+                        }
+                        c.Flush(1000);
+
+                        Thread.Sleep(1000);
+
+                        int r1 = s1.QueuedMessageCount;
+                        int r2 = s2.QueuedMessageCount;
+
+                        Assert.Equal(total, r1 + r2);
+
+                        Assert.False(Math.Abs(r1 - r2) > total * .15, string.Format("Too much variance between {0} and {1}", r1, r2));
                     }
-                    c.Flush(1000);
-
-                    Thread.Sleep(1000);
-
-                    int r1 = s1.QueuedMessageCount;
-                    int r2 = s2.QueuedMessageCount;
-
-                    Assert.Equal(total, r1 + r2);
-
-                    Assert.False(Math.Abs(r1 - r2) > total * .15, string.Format("Too much variance between {0} and {1}", r1, r2));
                 }
             }
         }
@@ -256,23 +269,26 @@ namespace NATSUnitTests
         [Fact]
         public void TestReplyArg()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (IAsyncSubscription s = c.SubscribeAsync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    s.MessageHandler += ExpectedReplyHandler;
-                    s.Start();
-
-                    lock (mu)
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                     {
-                        received = false;
-                        c.Publish("foo", "bar", null);
-                        Monitor.Wait(mu, 5000);
+                        s.MessageHandler += ExpectedReplyHandler;
+                        s.Start();
+
+                        lock (mu)
+                        {
+                            received = false;
+                            c.Publish("foo", "bar", null);
+                            Monitor.Wait(mu, 5000);
+                        }
                     }
                 }
-            }
 
-            Assert.True(received);
+                Assert.True(received);
+            }
         }
 
         private void ExpectedReplyHandler(object sender, MsgHandlerEventArgs args)
@@ -289,16 +305,20 @@ namespace NATSUnitTests
         [Fact]
         public void TestSyncReplyArg()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (ISyncSubscription s = c.SubscribeSync("foo"))
+
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    c.Publish("foo", "bar", null);
-                    c.Flush(30000);
+                    using (ISyncSubscription s = c.SubscribeSync("foo"))
+                    {
+                        c.Publish("foo", "bar", null);
+                        c.Flush(30000);
 
-                    Msg m = s.NextMessage(1000);
+                        Msg m = s.NextMessage(1000);
 
-                    Assert.Equal("bar", m.Reply);
+                        Assert.Equal("bar", m.Reply);
+                    }
                 }
             }
         }
@@ -309,59 +329,65 @@ namespace NATSUnitTests
             int count = 0;
             int max = 20;
 
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (IAsyncSubscription s = c.SubscribeAsync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    Boolean unsubscribed = false;
-                    asyncSub = s;
-                    //s.MessageHandler += UnsubscribeAfterCount;
-                    s.MessageHandler += (sender, args) =>
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                     {
-                        count++;
-                        if (count == max)
+                        Boolean unsubscribed = false;
+                        asyncSub = s;
+                        //s.MessageHandler += UnsubscribeAfterCount;
+                        s.MessageHandler += (sender, args) =>
                         {
-                            asyncSub.Unsubscribe();
-                            lock (mu)
+                            count++;
+                            if (count == max)
                             {
-                                unsubscribed = true;
-                                Monitor.Pulse(mu);
+                                asyncSub.Unsubscribe();
+                                lock (mu)
+                                {
+                                    unsubscribed = true;
+                                    Monitor.Pulse(mu);
+                                }
+                            }
+                        };
+                        s.Start();
+
+                        max = 20;
+                        for (int i = 0; i < max; i++)
+                        {
+                            c.Publish("foo", null, null);
+                        }
+                        Thread.Sleep(100);
+                        c.Flush();
+
+                        lock (mu)
+                        {
+                            if (!unsubscribed)
+                            {
+                                Monitor.Wait(mu, 5000);
                             }
                         }
-                    };
-                    s.Start();
-
-                    max = 20;
-                    for (int i = 0; i < max; i++)
-                    {
-                        c.Publish("foo", null, null);
                     }
-                    Thread.Sleep(100);
-                    c.Flush();
 
-                    lock (mu)
-                    {
-                        if (!unsubscribed)
-                        {
-                            Monitor.Wait(mu, 5000);
-                        }
-                    }
+                    Assert.Equal(max, count);
                 }
-
-                Assert.Equal(max, count);
             }
         }
 
         [Fact]
         public void TestDoubleUnsubscribe()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (ISyncSubscription s = c.SubscribeSync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    s.Unsubscribe();
+                    using (ISyncSubscription s = c.SubscribeSync("foo"))
+                    {
+                        s.Unsubscribe();
 
-                    Assert.ThrowsAny<Exception>(() => s.Unsubscribe());
+                        Assert.ThrowsAny<Exception>(() => s.Unsubscribe());
+                    }
                 }
             }
         }
@@ -369,33 +395,39 @@ namespace NATSUnitTests
         [Fact]
         public void TestRequestTimeout()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                Assert.ThrowsAny<Exception>(() => c.Request("foo", null, 500));
+                using (IConnection c = utils.DefaultTestConnection)
+                {
+                    Assert.ThrowsAny<Exception>(() => c.Request("foo", null, 500));
+                }
             }
         }
 
         [Fact]
         public void TestRequest()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (IAsyncSubscription s = c.SubscribeAsync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    byte[] response = Encoding.UTF8.GetBytes("I will help you.");
-
-                    s.MessageHandler += (sender, args) =>
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                     {
-                        c.Publish(args.Message.Reply, response);
-                        c.Flush();
-                    };
+                        byte[] response = Encoding.UTF8.GetBytes("I will help you.");
 
-                    s.Start();
+                        s.MessageHandler += (sender, args) =>
+                        {
+                            c.Publish(args.Message.Reply, response);
+                            c.Flush();
+                        };
 
-                    Msg m = c.Request("foo", Encoding.UTF8.GetBytes("help."),
-                        5000);
+                        s.Start();
 
-                    Assert.True(compare(m.Data, response), "Response isn't valid");
+                        Msg m = c.Request("foo", Encoding.UTF8.GetBytes("help."),
+                            5000);
+
+                        Assert.True(compare(m.Data, response), "Response isn't valid");
+                    }
                 }
             }
         }
@@ -403,59 +435,65 @@ namespace NATSUnitTests
         [Fact]
         public void TestRequestNoBody()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (IAsyncSubscription s = c.SubscribeAsync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    byte[] response = Encoding.UTF8.GetBytes("I will help you.");
-
-                    s.MessageHandler += (sender, args) =>
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                     {
-                        c.Publish(args.Message.Reply, response);
-                    };
+                        byte[] response = Encoding.UTF8.GetBytes("I will help you.");
 
-                    s.Start();
+                        s.MessageHandler += (sender, args) =>
+                        {
+                            c.Publish(args.Message.Reply, response);
+                        };
 
-                    Msg m = c.Request("foo", null, 50000);
+                        s.Start();
 
-                    Assert.True(compare(m.Data, response), "Response isn't valid");
+                        Msg m = c.Request("foo", null, 50000);
+
+                        Assert.True(compare(m.Data, response), "Response isn't valid");
+                    }
                 }
             }
         }
 
         public async void testRequestAsync()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                byte[] response = Encoding.UTF8.GetBytes("I will help you.");
-
-                EventHandler<MsgHandlerEventArgs> eh = (sender, args) =>
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    c.Publish(args.Message.Reply, response);
-                };
+                    byte[] response = Encoding.UTF8.GetBytes("I will help you.");
 
-                using (IAsyncSubscription s = c.SubscribeAsync("foo", eh))
-                {
-                    var tasks = new List<Task>();
-                    for (int i = 0; i < 100; i++)
+                    EventHandler<MsgHandlerEventArgs> eh = (sender, args) =>
                     {
-                        tasks.Add(c.RequestAsync("foo", null));
+                        c.Publish(args.Message.Reply, response);
+                    };
+
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo", eh))
+                    {
+                        var tasks = new List<Task>();
+                        for (int i = 0; i < 100; i++)
+                        {
+                            tasks.Add(c.RequestAsync("foo", null));
+                        }
+
+                        foreach (Task<Msg> t in tasks)
+                        {
+                            Msg m = await t;
+                            Assert.True(compare(m.Data, response), "Response isn't valid");
+                        }
                     }
 
-                    foreach (Task<Msg> t in tasks)
-                    {
-                        Msg m = await t;
-                        Assert.True(compare(m.Data, response), "Response isn't valid");
-                    }
+                    // test timeout, make sure we're close.
+                    Stopwatch sw = Stopwatch.StartNew();
+                    await Assert.ThrowsAsync<NATSTimeoutException>(() => { return c.RequestAsync("no-replier", null, 250); });
+                    sw.Stop();
+                    Assert.True(Math.Abs(sw.Elapsed.TotalMilliseconds - 250) < 50);
+
+                    await Assert.ThrowsAsync<NATSBadSubscriptionException>(() => { return c.RequestAsync("", null); });
                 }
-
-                // test timeout, make sure we're close.
-                Stopwatch sw = Stopwatch.StartNew();
-                await Assert.ThrowsAsync<NATSTimeoutException>(() => { return c.RequestAsync("no-replier", null, 250); });
-                sw.Stop();
-                Assert.True(Math.Abs(sw.Elapsed.TotalMilliseconds - 250) < 50);
-
-                await Assert.ThrowsAsync<NATSBadSubscriptionException>(() => { return c.RequestAsync("", null); });
             }
         }
 
@@ -467,69 +505,72 @@ namespace NATSUnitTests
 
         public async void testRequestAsyncCancellation()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                int responseDelay = 0;
-
-                byte[] response = Encoding.UTF8.GetBytes("I will help you.");
-
-                EventHandler<MsgHandlerEventArgs> eh = (sender, args) =>
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    if (responseDelay > 0)
-                        Thread.Sleep(responseDelay);
+                    int responseDelay = 0;
 
-                    c.Publish(args.Message.Reply, response);
-                };
+                    byte[] response = Encoding.UTF8.GetBytes("I will help you.");
 
-                // test cancellation success.
-                var miscToken = new CancellationTokenSource().Token;
-                using (IAsyncSubscription s = c.SubscribeAsync("foo", eh))
-                {
-                    var tasks = new List<Task>();
-                    for (int i = 0; i < 1000; i++)
+                    EventHandler<MsgHandlerEventArgs> eh = (sender, args) =>
                     {
-                        tasks.Add(c.RequestAsync("foo", null, miscToken));
+                        if (responseDelay > 0)
+                            Thread.Sleep(responseDelay);
+
+                        c.Publish(args.Message.Reply, response);
+                    };
+
+                    // test cancellation success.
+                    var miscToken = new CancellationTokenSource().Token;
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo", eh))
+                    {
+                        var tasks = new List<Task>();
+                        for (int i = 0; i < 1000; i++)
+                        {
+                            tasks.Add(c.RequestAsync("foo", null, miscToken));
+                        }
+
+                        foreach (Task<Msg> t in tasks)
+                        {
+                            Msg m = await t;
+                            Assert.True(compare(m.Data, response), "Response isn't valid");
+                        }
+
                     }
 
-                    foreach (Task<Msg> t in tasks)
-                    {
-                        Msg m = await t;
-                        Assert.True(compare(m.Data, response), "Response isn't valid");
-                    }
+                    // test timeout, make sure we are close.
+                    Stopwatch sw = Stopwatch.StartNew();
+                    await Assert.ThrowsAsync<NATSTimeoutException>(() => { return c.RequestAsync("no-replier", null, 250, miscToken); });
+                    sw.Stop();
+                    Assert.True(Math.Abs(sw.Elapsed.TotalMilliseconds - 250) < 50);
 
-                }
+                    // test early cancellation
+                    var cts = new CancellationTokenSource();
+                    var ct = cts.Token;
+                    cts.Cancel();
+                    await Assert.ThrowsAsync<TaskCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
 
-                // test timeout, make sure we are close.
-                Stopwatch sw = Stopwatch.StartNew();
-                await Assert.ThrowsAsync<NATSTimeoutException>(() => { return c.RequestAsync("no-replier", null, 250, miscToken); });
-                sw.Stop();
-                Assert.True(Math.Abs(sw.Elapsed.TotalMilliseconds - 250) < 50);
-
-                // test early cancellation
-                var cts = new CancellationTokenSource();
-                var ct = cts.Token;
-                cts.Cancel();
-                await Assert.ThrowsAsync<TaskCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
-
-                // test cancellation
-                cts = new CancellationTokenSource();
-                var ocex = Assert.ThrowsAsync<OperationCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
-                Thread.Sleep(250);
-                cts.Cancel();
-                await ocex;
-
-                // now we want to test a slow replier, to make sure wait logic checking 
-                responseDelay = 500;
-                using (IAsyncSubscription s = c.SubscribeAsync("foo", eh))
-                {
-                    await c.RequestAsync("foo", null, miscToken);
-
-                    // test cancellation with a subscriber
+                    // test cancellation
                     cts = new CancellationTokenSource();
-                    ocex = Assert.ThrowsAsync<OperationCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
-                    Thread.Sleep(responseDelay / 2);
+                    var ocex = Assert.ThrowsAsync<OperationCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
+                    Thread.Sleep(250);
                     cts.Cancel();
                     await ocex;
+
+                    // now we want to test a slow replier, to make sure wait logic checking 
+                    responseDelay = 500;
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo", eh))
+                    {
+                        await c.RequestAsync("foo", null, miscToken);
+
+                        // test cancellation with a subscriber
+                        cts = new CancellationTokenSource();
+                        ocex = Assert.ThrowsAsync<OperationCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
+                        Thread.Sleep(responseDelay / 2);
+                        cts.Cancel();
+                        await ocex;
+                    }
                 }
             }
         }
@@ -583,58 +624,60 @@ namespace NATSUnitTests
             byte[] response = Encoding.UTF8.GetBytes("reply");
 
             ThreadPool.SetMinThreads(300, 300);
-
-            using (IConnection c1 = utils.DefaultTestConnection,
-                               c2 = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (IAsyncSubscription s = c1.SubscribeAsync("foo", (sender, args) =>
+                using (IConnection c1 = utils.DefaultTestConnection,
+                               c2 = utils.DefaultTestConnection)
                 {
+                    using (IAsyncSubscription s = c1.SubscribeAsync("foo", (sender, args) =>
+                    {
                     // We cannot block this thread... so copy our data, and spawn a thread
                     // to handle a delay and responding.
                     TestReplier t = new TestReplier(c1, MAX_DELAY,
-                        Encoding.UTF8.GetString(args.Message.Data),
-                        args.Message.Reply,
-                        sw);
-                    new Thread(() => { t.process(); }).Start();
-                }))
-                {
-                    c1.Flush();
-
-                    // use lower level threads over tasks here for predictibility
-                    Thread[] threads = new Thread[TEST_COUNT];
-                    Random r = new Random();
-
-                    for (int i = 0; i < TEST_COUNT; i++)
+                            Encoding.UTF8.GetString(args.Message.Data),
+                            args.Message.Reply,
+                            sw);
+                        new Thread(() => { t.process(); }).Start();
+                    }))
                     {
-                        threads[i] = new Thread((() =>
+                        c1.Flush();
+
+                        // use lower level threads over tasks here for predictibility
+                        Thread[] threads = new Thread[TEST_COUNT];
+                        Random r = new Random();
+
+                        for (int i = 0; i < TEST_COUNT; i++)
                         {
+                            threads[i] = new Thread((() =>
+                            {
                             // randomly delay for a bit to test potential timing issues.
                             Thread.Sleep(r.Next(100, 500));
-                            c2.Request("foo", null, MAX_DELAY * 2);
-                        }));
+                                c2.Request("foo", null, MAX_DELAY * 2);
+                            }));
+                        }
+
+                        // sleep for one second to allow the threads to initialize.
+                        Thread.Sleep(1000);
+
+                        sw.Start();
+
+                        // start all of the threads at the same time.
+                        for (int i = 0; i < TEST_COUNT; i++)
+                        {
+                            threads[i].Start();
+                        }
+
+                        // wait for every thread to stop.
+                        for (int i = 0; i < TEST_COUNT; i++)
+                        {
+                            threads[i].Join();
+                        }
+
+                        sw.Stop();
+
+                        // check that we didn't process the requests consecutively.
+                        Assert.True(sw.ElapsedMilliseconds < (MAX_DELAY * 2));
                     }
-
-                    // sleep for one second to allow the threads to initialize.
-                    Thread.Sleep(1000);
-
-                    sw.Start();
-
-                    // start all of the threads at the same time.
-                    for (int i = 0; i < TEST_COUNT; i++)
-                    {
-                        threads[i].Start();
-                    }
-
-                    // wait for every thread to stop.
-                    for (int i = 0; i < TEST_COUNT; i++)
-                    {
-                        threads[i].Join();
-                    }
-
-                    sw.Stop();
-
-                    // check that we didn't process the requests consecutively.
-                    Assert.True(sw.ElapsedMilliseconds < (MAX_DELAY * 2));
                 }
             }
         }
@@ -655,54 +698,57 @@ namespace NATSUnitTests
             Stopwatch sw = new Stopwatch();
             byte[] response = Encoding.UTF8.GetBytes("reply");
 
-            using (IConnection c1 = utils.DefaultTestConnection,
-                               c2 = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                // Try parallel requests and check the performance.
-                using (IAsyncSubscription s = c1.SubscribeAsync("foo", (sender, args) =>
+                using (IConnection c1 = utils.DefaultTestConnection,
+                               c2 = utils.DefaultTestConnection)
                 {
+                    // Try parallel requests and check the performance.
+                    using (IAsyncSubscription s = c1.SubscribeAsync("foo", (sender, args) =>
+                    {
                     // We cannot block this NATS thread... so copy our data, and spawn a thread
                     // to handle a delay and responding.
                     TestReplier t = new TestReplier(c1, MAX_DELAY,
-                        Encoding.UTF8.GetString(args.Message.Data),
-                        args.Message.Reply,
-                        sw);
-                    new Task(() => { t.process(); }).Start();
-                }))
-                {
-                    c1.Flush();
-
-                    // Depending on resources, Tasks can be queueud up for quite while.
-                    Task[] tasks = new Task[TEST_COUNT];
-                    Random r = new Random();
-
-                    for (int i = 0; i < TEST_COUNT; i++)
+                            Encoding.UTF8.GetString(args.Message.Data),
+                            args.Message.Reply,
+                            sw);
+                        new Task(() => { t.process(); }).Start();
+                    }))
                     {
-                        tasks[i] = new Task((() =>
+                        c1.Flush();
+
+                        // Depending on resources, Tasks can be queueud up for quite while.
+                        Task[] tasks = new Task[TEST_COUNT];
+                        Random r = new Random();
+
+                        for (int i = 0; i < TEST_COUNT; i++)
                         {
+                            tasks[i] = new Task((() =>
+                            {
                             // randomly delay for a bit to test potential timing issues.
                             Thread.Sleep(r.Next(100, 500));
-                            c2.Request("foo", null, MAX_DELAY * 2);
-                        }));
+                                c2.Request("foo", null, MAX_DELAY * 2);
+                            }));
+                        }
+
+                        // sleep for one second to allow the tasks to initialize.
+                        Thread.Sleep(1000);
+
+                        sw.Start();
+
+                        // start all of the threads at the same time.
+                        for (int i = 0; i < TEST_COUNT; i++)
+                        {
+                            tasks[i].Start();
+                        }
+
+                        Task.WaitAll(tasks);
+
+                        sw.Stop();
+
+                        // check that we didn't process the requests consecutively.
+                        Assert.True(sw.ElapsedMilliseconds < (MAX_DELAY * 2));
                     }
-
-                    // sleep for one second to allow the tasks to initialize.
-                    Thread.Sleep(1000);
-
-                    sw.Start();
-
-                    // start all of the threads at the same time.
-                    for (int i = 0; i < TEST_COUNT; i++)
-                    {
-                        tasks[i].Start();
-                    }
-
-                    Task.WaitAll(tasks);
-
-                    sw.Stop();
-
-                    // check that we didn't process the requests consecutively.
-                    Assert.True(sw.ElapsedMilliseconds < (MAX_DELAY * 2));
                 }
             }
         }
@@ -711,28 +757,31 @@ namespace NATSUnitTests
         [Fact]
         public void TestFlushInHandler()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (IAsyncSubscription s = c.SubscribeAsync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    byte[] response = Encoding.UTF8.GetBytes("I will help you.");
-
-                    s.MessageHandler += (sender, args) =>
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                     {
-                        c.Flush();
+                        byte[] response = Encoding.UTF8.GetBytes("I will help you.");
+
+                        s.MessageHandler += (sender, args) =>
+                        {
+                            c.Flush();
+
+                            lock (mu)
+                            {
+                                Monitor.Pulse(mu);
+                            }
+                        };
+
+                        s.Start();
 
                         lock (mu)
                         {
-                            Monitor.Pulse(mu);
+                            c.Publish("foo", Encoding.UTF8.GetBytes("Hello"));
+                            Monitor.Wait(mu);
                         }
-                    };
-
-                    s.Start();
-
-                    lock (mu)
-                    {
-                        c.Publish("foo", Encoding.UTF8.GetBytes("Hello"));
-                        Monitor.Wait(mu);
                     }
                 }
             }
@@ -741,143 +790,166 @@ namespace NATSUnitTests
         [Fact]
         public void TestReleaseFlush()
         {
-            IConnection c = utils.DefaultTestConnection;
-
-            for (int i = 0; i < 1000; i++)
+            using (new NATSServer())
             {
-                c.Publish("foo", Encoding.UTF8.GetBytes("Hello"));
-            }
+                IConnection c = utils.DefaultTestConnection;
 
-            new Task(() => { c.Close(); }).Start();
-            c.Flush();
+                for (int i = 0; i < 1000; i++)
+                {
+                    c.Publish("foo", Encoding.UTF8.GetBytes("Hello"));
+                }
+
+                new Task(() => { c.Close(); }).Start();
+                c.Flush();
+            }
         }
 
         [Fact]
         public void TestCloseAndDispose()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                c.Close();
+                using (IConnection c = utils.DefaultTestConnection)
+                {
+                    c.Close();
+                }
             }
         }
 
         [Fact]
         public void TestInbox()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                string inbox = c.NewInbox();
-                Assert.False(string.IsNullOrWhiteSpace(inbox));
-                Assert.True(inbox.StartsWith("_INBOX."));
+                using (IConnection c = utils.DefaultTestConnection)
+                {
+                    string inbox = c.NewInbox();
+                    Assert.False(string.IsNullOrWhiteSpace(inbox));
+                    Assert.True(inbox.StartsWith("_INBOX."));
+                }
             }
         }
 
         [Fact]
         public void TestStats()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                byte[] data = Encoding.UTF8.GetBytes("The quick brown fox jumped over the lazy dog");
-                int iter = 10;
-
-                for (int i = 0; i < iter; i++)
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    c.Publish("foo", data);
+                    byte[] data = Encoding.UTF8.GetBytes("The quick brown fox jumped over the lazy dog");
+                    int iter = 10;
+
+                    for (int i = 0; i < iter; i++)
+                    {
+                        c.Publish("foo", data);
+                    }
+                    c.Flush(1000);
+
+                    IStatistics stats = c.Stats;
+                    Assert.Equal(iter, stats.OutMsgs);
+                    Assert.Equal(iter * data.Length, stats.OutBytes);
+
+                    c.ResetStats();
+
+                    // Test both sync and async versions of subscribe.
+                    IAsyncSubscription s1 = c.SubscribeAsync("foo");
+                    s1.MessageHandler += (sender, arg) => { };
+                    s1.Start();
+
+                    ISyncSubscription s2 = c.SubscribeSync("foo");
+
+                    for (int i = 0; i < iter; i++)
+                    {
+                        c.Publish("foo", data);
+                    }
+                    c.Flush(1000);
+
+                    stats = c.Stats;
+                    Assert.Equal(2 * iter, stats.InMsgs);
+                    Assert.Equal(2 * iter * data.Length, stats.InBytes);
                 }
-                c.Flush(1000);
-
-                IStatistics stats = c.Stats;
-                Assert.Equal(iter, stats.OutMsgs);
-                Assert.Equal(iter * data.Length, stats.OutBytes);
-
-                c.ResetStats();
-
-                // Test both sync and async versions of subscribe.
-                IAsyncSubscription s1 = c.SubscribeAsync("foo");
-                s1.MessageHandler += (sender, arg) => { };
-                s1.Start();
-
-                ISyncSubscription s2 = c.SubscribeSync("foo");
-
-                for (int i = 0; i < iter; i++)
-                {
-                    c.Publish("foo", data);
-                }
-                c.Flush(1000);
-
-                stats = c.Stats;
-                Assert.Equal(2 * iter, stats.InMsgs);
-                Assert.Equal(2 * iter * data.Length, stats.InBytes);
             }
         }
 
         [Fact]
         public void TestRaceSafeStats()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer(false))
             {
-
-                new Task(() => { c.Publish("foo", null); }).Start();
-
                 Thread.Sleep(1000);
 
-                Assert.Equal(1, c.Stats.OutMsgs);
+                using (IConnection c = utils.DefaultTestConnection)
+                {
+
+                    new Task(() => { c.Publish("foo", null); }).Start();
+
+                    Thread.Sleep(1000);
+
+                    Assert.Equal(1, c.Stats.OutMsgs);
+                }
             }
         }
 
         [Fact]
         public void TestBadSubject()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                bool exThrown = false;
-                try
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    c.Publish("", null);
+                    bool exThrown = false;
+                    try
+                    {
+                        c.Publish("", null);
+                    }
+                    catch (Exception e)
+                    {
+                        if (e is NATSBadSubscriptionException)
+                            exThrown = true;
+                    }
+                    Assert.True(exThrown);
                 }
-                catch (Exception e)
-                {
-                    if (e is NATSBadSubscriptionException)
-                        exThrown = true;
-                }
-                Assert.True(exThrown);
             }
         }
 
         [Fact]
         public void TestLargeMessage()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                int msgSize = 51200;
-                byte[] msg = new byte[msgSize];
-
-                for (int i = 0; i < msgSize; i++)
-                    msg[i] = (byte)'A';
-
-                msg[msgSize - 1] = (byte)'Z';
-
-                using (IAsyncSubscription s = c.SubscribeAsync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    Object testLock = new Object();
+                    int msgSize = 51200;
+                    byte[] msg = new byte[msgSize];
 
-                    s.MessageHandler += (sender, args) =>
+                    for (int i = 0; i < msgSize; i++)
+                        msg[i] = (byte)'A';
+
+                    msg[msgSize - 1] = (byte)'Z';
+
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                     {
+                        Object testLock = new Object();
+
+                        s.MessageHandler += (sender, args) =>
+                        {
+                            lock (testLock)
+                            {
+                                Monitor.Pulse(testLock);
+                            }
+                            Assert.True(compare(msg, args.Message.Data));
+                        };
+
+                        s.Start();
+
+                        c.Publish("foo", msg);
+                        c.Flush(1000);
+
                         lock (testLock)
                         {
-                            Monitor.Pulse(testLock);
+                            Monitor.Wait(testLock, 2000);
                         }
-                        Assert.True(compare(msg, args.Message.Data));
-                    };
-
-                    s.Start();
-
-                    c.Publish("foo", msg);
-                    c.Flush(1000);
-
-                    lock (testLock)
-                    {
-                        Monitor.Wait(testLock, 2000);
                     }
                 }
             }
@@ -886,29 +958,32 @@ namespace NATSUnitTests
         [Fact]
         public void TestSendAndRecv()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                using (IAsyncSubscription s = c.SubscribeAsync("foo"))
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    int received = 0;
-                    int count = 1000;
-
-                    s.MessageHandler += (sender, args) =>
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                     {
-                        Interlocked.Increment(ref received);
-                    };
+                        int received = 0;
+                        int count = 1000;
 
-                    s.Start();
+                        s.MessageHandler += (sender, args) =>
+                        {
+                            Interlocked.Increment(ref received);
+                        };
 
-                    for (int i = 0; i < count; i++)
-                    {
-                        c.Publish("foo", null);
+                        s.Start();
+
+                        for (int i = 0; i < count; i++)
+                        {
+                            c.Publish("foo", null);
+                        }
+                        c.Flush();
+
+                        Thread.Sleep(500);
+
+                        Assert.Equal(count, received);
                     }
-                    c.Flush();
-
-                    Thread.Sleep(500);
-
-                    Assert.Equal(count, received);
                 }
             }
         }
@@ -917,42 +992,45 @@ namespace NATSUnitTests
         [Fact]
         public void TestLargeSubjectAndReply()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                String subject = "";
-                for (int i = 0; i < 1024; i++)
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    subject += "A";
-                }
-
-                String reply = "";
-                for (int i = 0; i < 1024; i++)
-                {
-                    reply += "A";
-                }
-
-                using (IAsyncSubscription s = c.SubscribeAsync(subject))
-                {
-                    AutoResetEvent ev = new AutoResetEvent(false);
-                    string recvSubj = null;
-                    string recvReply = null;
-
-                    s.MessageHandler += (sender, args) =>
+                    String subject = "";
+                    for (int i = 0; i < 1024; i++)
                     {
-                        recvSubj = args.Message.Subject;
-                        recvReply = args.Message.Reply;
+                        subject += "A";
+                    }
 
-                        ev.Set();
-                    };
+                    String reply = "";
+                    for (int i = 0; i < 1024; i++)
+                    {
+                        reply += "A";
+                    }
 
-                    s.Start();
+                    using (IAsyncSubscription s = c.SubscribeAsync(subject))
+                    {
+                        AutoResetEvent ev = new AutoResetEvent(false);
+                        string recvSubj = null;
+                        string recvReply = null;
 
-                    c.Publish(subject, reply, null);
-                    c.Flush();
+                        s.MessageHandler += (sender, args) =>
+                        {
+                            recvSubj = args.Message.Subject;
+                            recvReply = args.Message.Reply;
 
-                    Assert.True(ev.WaitOne(10000));
-                    Assert.Equal(subject, recvSubj);
-                    Assert.Equal(reply, recvReply);
+                            ev.Set();
+                        };
+
+                        s.Start();
+
+                        c.Publish(subject, reply, null);
+                        c.Flush();
+
+                        Assert.True(ev.WaitOne(10000));
+                        Assert.Equal(subject, recvSubj);
+                        Assert.Equal(reply, recvReply);
+                    }
                 }
             }
         }
@@ -960,30 +1038,33 @@ namespace NATSUnitTests
         [Fact]
         public void TestAsyncSubHandlerAPI()
         {
-            using (IConnection c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                int received = 0;
-
-                EventHandler<MsgHandlerEventArgs> h = (sender, args) =>
+                using (IConnection c = utils.DefaultTestConnection)
                 {
-                    Interlocked.Increment(ref received);
-                };
+                    int received = 0;
 
-                using (IAsyncSubscription s = c.SubscribeAsync("foo", h))
-                {
-                    c.Publish("foo", null);
-                    c.Flush();
-                    Thread.Sleep(500);
+                    EventHandler<MsgHandlerEventArgs> h = (sender, args) =>
+                    {
+                        Interlocked.Increment(ref received);
+                    };
+
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo", h))
+                    {
+                        c.Publish("foo", null);
+                        c.Flush();
+                        Thread.Sleep(500);
+                    }
+
+                    using (IAsyncSubscription s = c.SubscribeAsync("foo", "bar", h))
+                    {
+                        c.Publish("foo", null);
+                        c.Flush();
+                        Thread.Sleep(500);
+                    }
+
+                    Assert.Equal(2, received);
                 }
-
-                using (IAsyncSubscription s = c.SubscribeAsync("foo", "bar", h))
-                {
-                    c.Publish("foo", null);
-                    c.Flush();
-                    Thread.Sleep(500);
-                }
-
-                Assert.Equal(2, received);
             }
         }
 
@@ -995,22 +1076,26 @@ namespace NATSUnitTests
             string url3 = "nats://localhost:4224";
 
             string urls = url1 + "," + url2 + "," + url3;
-            IConnection c = new ConnectionFactory().CreateConnection(urls);
-            Assert.True(c.Opts.Servers[0].Equals(url1));
-            Assert.True(c.Opts.Servers[1].Equals(url2));
-            Assert.True(c.Opts.Servers[2].Equals(url3));
 
-            c.Close();
+            using (new NATSServer())
+            {
+                IConnection c = new ConnectionFactory().CreateConnection(urls);
+                Assert.True(c.Opts.Servers[0].Equals(url1));
+                Assert.True(c.Opts.Servers[1].Equals(url2));
+                Assert.True(c.Opts.Servers[2].Equals(url3));
 
-            urls = url1 + "    , " + url2 + "," + url3;
-            c = new ConnectionFactory().CreateConnection(urls);
-            Assert.True(c.Opts.Servers[0].Equals(url1));
-            Assert.True(c.Opts.Servers[1].Equals(url2));
-            Assert.True(c.Opts.Servers[2].Equals(url3));
-            c.Close();
+                c.Close();
 
-            c = new ConnectionFactory().CreateConnection(url1);
-            c.Close();
+                urls = url1 + "    , " + url2 + "," + url3;
+                c = new ConnectionFactory().CreateConnection(urls);
+                Assert.True(c.Opts.Servers[0].Equals(url1));
+                Assert.True(c.Opts.Servers[1].Equals(url2));
+                Assert.True(c.Opts.Servers[2].Equals(url3));
+                c.Close();
+
+                c = new ConnectionFactory().CreateConnection(url1);
+                c.Close();
+            }
         }
 
         [Fact]
@@ -1109,24 +1194,25 @@ namespace NATSUnitTests
             opts.Servers = serverList;
             opts.NoRandomize = true;
 
-
-            var c = new ConnectionFactory().CreateConnection(opts);
-            Assert.True(listsEqual(serverList, c.Servers));
-            c.Close();
-
-            bool wasRandom = false;
-            opts.NoRandomize = false;
-            for (int i = 0; i < 5; i++)
+            using (new NATSServer())
             {
-                c = new ConnectionFactory().CreateConnection(opts);
-                wasRandom = (listsEqual(serverList, c.Servers) == false);
+                var c = new ConnectionFactory().CreateConnection(opts);
+                Assert.True(listsEqual(serverList, c.Servers));
                 c.Close();
 
-                if (wasRandom)
-                    break;
-            }
+                bool wasRandom = false;
+                opts.NoRandomize = false;
+                for (int i = 0; i < 5; i++)
+                {
+                    c = new ConnectionFactory().CreateConnection(opts);
+                    wasRandom = (listsEqual(serverList, c.Servers) == false);
+                    c.Close();
 
-            Assert.True(wasRandom);
+                    if (wasRandom)
+                        break;
+                }
+
+                Assert.True(wasRandom);
 
 #if skip
             // Although the original intent was that if Opts.Url is
@@ -1145,6 +1231,7 @@ namespace NATSUnitTests
                     break;
             }
 #endif
+            }
         }
 
     } // class

--- a/NATSUnitTests/UnitTestCluster.cs
+++ b/NATSUnitTests/UnitTestCluster.cs
@@ -131,7 +131,7 @@ namespace NATSUnitTests
                 }
             };
 
-            opts.Timeout = 200;
+            opts.Timeout = 1000;
 
             using (NATSServer s1 = utils.CreateServerOnPort(1222),
                               s2 = utils.CreateServerOnPort(1224))
@@ -388,7 +388,7 @@ namespace NATSUnitTests
             opts.NoRandomize = true;
             opts.MaxReconnect = 2;
             opts.ReconnectWait = 25; // millis
-            opts.Timeout = 500;
+            opts.Timeout = 1000;
 
             bool disconnectHandlerCalled = false;
 

--- a/NATSUnitTests/UnitTestCluster.cs
+++ b/NATSUnitTests/UnitTestCluster.cs
@@ -36,7 +36,7 @@ namespace NATSUnitTests
         {
             IConnection c = null;
             ConnectionFactory cf = new ConnectionFactory();
-            Options o = ConnectionFactory.GetDefaultOptions();
+            Options o = utils.DefaultTestOptions;
 
             o.NoRandomize = true;
 
@@ -71,7 +71,7 @@ namespace NATSUnitTests
 		        "nats://localhost:1224"
             };
 
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.NoRandomize = true;
             opts.Servers = plainServers;
             opts.Timeout = 5000;
@@ -103,7 +103,7 @@ namespace NATSUnitTests
 		        "nats://localhost:1224"
             };
 
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.MaxReconnect = 2;
             opts.ReconnectWait = 1000;
             opts.NoRandomize = true;
@@ -216,7 +216,7 @@ namespace NATSUnitTests
             int numClients = 10;
             SimClient[] clients = new SimClient[100];
 
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.Servers = testServers;
 
             NATSServer s1 = utils.CreateServerOnPort(1222);
@@ -267,7 +267,7 @@ namespace NATSUnitTests
         public void TestProperReconnectDelay()
         {
             Object mu = new Object();
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.Servers = testServers;
             opts.NoRandomize = true;
 
@@ -315,7 +315,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestProperFalloutAfterMaxAttempts()
         {
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
 
             Object dmu = new Object();
             Object cmu = new Object();
@@ -375,7 +375,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestProperFalloutAfterMaxAttemptsWithAuthMismatch()
         {
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
 
             Object dmu = new Object();
             Object cmu = new Object();
@@ -442,7 +442,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestTimeoutOnNoServers()
         {
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             Object dmu = new Object();
             Object cmu = new Object();
 
@@ -514,7 +514,7 @@ namespace NATSUnitTests
             /// Work in progress
             int RECONNECTS = 4;
 
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             Object mu = new Object();
 
             opts.Servers = testServersShortList;

--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -29,7 +29,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestConnectionStatus()
         {
-            IConnection c = new ConnectionFactory().CreateConnection();
+            IConnection c = utils.DefaultTestConnection;
             Assert.Equal(ConnState.CONNECTED, c.State);
             c.Close();
             Assert.Equal(ConnState.CLOSED, c.State);
@@ -40,7 +40,7 @@ namespace NATSUnitTests
         {
             bool closed = false;
 
-            Options o = ConnectionFactory.GetDefaultOptions();
+            Options o = utils.DefaultTestOptions;
             o.ClosedEventHandler += (sender, args) => { 
                 closed = true; };
             IConnection c = new ConnectionFactory().CreateConnection(o);
@@ -61,7 +61,7 @@ namespace NATSUnitTests
             bool disconnected = false;
             Object mu = new Object();
 
-            Options o = ConnectionFactory.GetDefaultOptions();
+            Options o = utils.DefaultTestOptions;
             o.AllowReconnect = false;
             o.DisconnectedEventHandler += (sender, args) => {
                 lock (mu)
@@ -95,7 +95,7 @@ namespace NATSUnitTests
             bool disconnected = false;
             Object mu = new Object();
 
-            Options o = ConnectionFactory.GetDefaultOptions();
+            Options o = utils.DefaultTestOptions;
             o.AllowReconnect = false;
             o.DisconnectedEventHandler += (sender, args) =>
             {
@@ -119,7 +119,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestClosedConnections()
         {
-            IConnection c = new ConnectionFactory().CreateConnection();
+            IConnection c = utils.DefaultTestConnection;
             ISyncSubscription s = c.SubscribeSync("foo");
 
             c.Close();
@@ -153,7 +153,7 @@ namespace NATSUnitTests
         public void TestConnectVerbose()
         {
 
-            Options o = ConnectionFactory.GetDefaultOptions();
+            Options o = utils.DefaultTestOptions;
             o.Verbose = true;
 
             IConnection c = new ConnectionFactory().CreateConnection(o);
@@ -186,7 +186,7 @@ namespace NATSUnitTests
 
             using (NATSServer s = utils.CreateServerWithConfig("auth_1222.conf"))
             {
-                Options o = ConnectionFactory.GetDefaultOptions();
+                Options o = utils.DefaultTestOptions;
 
                 o.DisconnectedEventHandler += (sender, args) =>
                 {
@@ -236,7 +236,7 @@ namespace NATSUnitTests
                 o.SubChannelLength = 1;
 
                 using (IConnection nc = new ConnectionFactory().CreateConnection(o),
-                       ncp = new ConnectionFactory().CreateConnection())
+                       ncp = utils.DefaultTestConnection)
                 {
                     // On hosted environments, some threads/tasks can start before others
                     // due to resource constraints.  Allow time to start.
@@ -355,7 +355,7 @@ namespace NATSUnitTests
         {
             // test that dispose code works after a connection
             // has been closed and cleaned up.
-            using (var c = new ConnectionFactory().CreateConnection())
+            using (var c = utils.DefaultTestConnection)
             {
                 c.Close();
                 Thread.Sleep(500);
@@ -363,14 +363,14 @@ namespace NATSUnitTests
 
             // attempt to test that dispose works while the connection close
             // has passed off work to cleanup the callback scheduler, etc.
-            using (var c = new ConnectionFactory().CreateConnection())
+            using (var c = utils.DefaultTestConnection)
             {
                 c.Close();
                 Thread.Sleep(500);
             }
 
             // Check that dispose is idempotent.
-            using (var c = new ConnectionFactory().CreateConnection())
+            using (var c = utils.DefaultTestConnection)
             {
                 c.Dispose();
             }
@@ -381,7 +381,7 @@ namespace NATSUnitTests
         {
             using (new NATSServer("-p 4444 --auth foo"))
             {
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = utils.DefaultTestOptions;
 
                 opts.Url = "nats://localhost:4444";
                 opts.Token = "foo";
@@ -394,7 +394,7 @@ namespace NATSUnitTests
 
             using (new NATSServer("-p 4444 --user foo --pass b@r"))
             {
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = utils.DefaultTestOptions;
 
                 opts.Url = "nats://localhost:4444";
                 opts.User = "foo";

--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -18,7 +18,7 @@ namespace NATSUnitTests
         public TestConnection()
         {
             UnitTestUtilities.CleanupExistingServers();
-            utils.StartDefaultServerAndDelay();
+            utils.StartDefaultServerAndVerify();
         }
         
         public void Dispose()

--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -11,153 +11,152 @@ namespace NATSUnitTests
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    public class TestConnection : IDisposable
+    public class TestConnection
     {
         UnitTestUtilities utils = new UnitTestUtilities();
-        
-        public TestConnection()
-        {
-            UnitTestUtilities.CleanupExistingServers();
-            utils.StartDefaultServerAndVerify();
-        }
-        
-        public void Dispose()
-        {
-            utils.StopDefaultServer();
-        }
         
         [Fact]
         public void TestConnectionStatus()
         {
-            IConnection c = utils.DefaultTestConnection;
-            Assert.Equal(ConnState.CONNECTED, c.State);
-            c.Close();
-            Assert.Equal(ConnState.CLOSED, c.State);
+            using (new NATSServer())
+            {
+                IConnection c = utils.DefaultTestConnection;
+                Assert.Equal(ConnState.CONNECTED, c.State);
+                c.Close();
+                Assert.Equal(ConnState.CLOSED, c.State);
+            }
         }
 
         [Fact]
         public void TestCloseHandler()
         {
-            bool closed = false;
+            AutoResetEvent ev = new AutoResetEvent(false);
+            using (new NATSServer())
+            {
+                Options o = utils.DefaultTestOptions;
+                o.ClosedEventHandler += (sender, args) =>
+                {
+                    ev.Set();
+                };
+                IConnection c = new ConnectionFactory().CreateConnection(o);
+                c.Close();
+                Assert.True(ev.WaitOne(1000));
 
-            Options o = utils.DefaultTestOptions;
-            o.ClosedEventHandler += (sender, args) => { 
-                closed = true; };
-            IConnection c = new ConnectionFactory().CreateConnection(o);
-            c.Close();
-            Thread.Sleep(1000);
-            Assert.True(closed);
-
-            // now test using.
-            closed = false;
-            using (c = new ConnectionFactory().CreateConnection(o)) { };
-            Thread.Sleep(1000);
-            Assert.True(closed);
+                // now test using.
+                ev.Reset();
+                using (c = new ConnectionFactory().CreateConnection(o)) { };
+                Assert.True(ev.WaitOne(1000));
+            }
         }
 
         [Fact]
         public void TestCloseDisconnectedHandler()
         {
-            bool disconnected = false;
-            Object mu = new Object();
+            using (new NATSServer())
+            {
+                bool disconnected = false;
+                Object mu = new Object();
 
-            Options o = utils.DefaultTestOptions;
-            o.AllowReconnect = false;
-            o.DisconnectedEventHandler += (sender, args) => {
+                Options o = utils.DefaultTestOptions;
+                o.AllowReconnect = false;
+                o.DisconnectedEventHandler += (sender, args) =>
+                {
+                    lock (mu)
+                    {
+                        disconnected = true;
+                        Monitor.Pulse(mu);
+                    }
+                };
+
+                IConnection c = new ConnectionFactory().CreateConnection(o);
                 lock (mu)
                 {
-                    disconnected = true;
-                    Monitor.Pulse(mu);
+                    c.Close();
+                    Monitor.Wait(mu, 20000);
                 }
-            };
+                Assert.True(disconnected);
 
-            IConnection c = new ConnectionFactory().CreateConnection(o);
-            lock (mu)
-            {
-                c.Close();
-                Monitor.Wait(mu, 20000);
+                // now test using.
+                disconnected = false;
+                lock (mu)
+                {
+                    using (c = new ConnectionFactory().CreateConnection(o)) { };
+                    Monitor.Wait(mu, 20000);
+                }
+                Assert.True(disconnected);
             }
-            Assert.True(disconnected);
-
-            // now test using.
-            disconnected = false;
-            lock (mu)
-            {
-                using (c = new ConnectionFactory().CreateConnection(o)) { };
-                Monitor.Wait(mu, 20000);
-            }
-            Assert.True(disconnected);
         }
 
         [Fact]
         public void TestServerStopDisconnectedHandler()
         {
-            bool disconnected = false;
-            Object mu = new Object();
-
-            Options o = utils.DefaultTestOptions;
-            o.AllowReconnect = false;
-            o.DisconnectedEventHandler += (sender, args) =>
+            using (var s = new NATSServer())
             {
-                lock (mu)
+                AutoResetEvent ev = new AutoResetEvent(false);
+
+                Options o = utils.DefaultTestOptions;
+                o.AllowReconnect = false;
+                o.DisconnectedEventHandler += (sender, args) =>
                 {
-                    disconnected = true;
-                    Monitor.Pulse(mu);
-                }
-            };
+                    ev.Set();
+                };
 
-            IConnection c = new ConnectionFactory().CreateConnection(o);
-            lock (mu)
-            {
-                utils.bounceDefaultServer(1000);
-                Monitor.Wait(mu, 10000);
+                IConnection c = new ConnectionFactory().CreateConnection(o);
+                s.Bounce(1000);
+
+                Assert.True(ev.WaitOne(10000));
+
+                c.Close();
             }
-            c.Close();
-            Assert.True(disconnected);
         }
 
         [Fact]
         public void TestClosedConnections()
         {
-            IConnection c = utils.DefaultTestConnection;
-            ISyncSubscription s = c.SubscribeSync("foo");
+            using (new NATSServer())
+            {
+                IConnection c = utils.DefaultTestConnection;
+                ISyncSubscription s = c.SubscribeSync("foo");
 
-            c.Close();
+                c.Close();
 
-            // While we can annotate all the exceptions in the test framework,
-            // just do it manually.
-            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.Publish("foo", null));
+                // While we can annotate all the exceptions in the test framework,
+                // just do it manually.
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => c.Publish("foo", null));
 
-            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.Publish(new Msg("foo")));
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => c.Publish(new Msg("foo")));
 
-            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeAsync("foo"));
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeAsync("foo"));
 
-            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeSync("foo"));
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeSync("foo"));
 
-            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeAsync("foo", "bar"));
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeAsync("foo", "bar"));
 
-            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeSync("foo", "bar"));
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => c.SubscribeSync("foo", "bar"));
 
-            Assert.ThrowsAny<NATSConnectionClosedException>(() => c.Request("foo", null));
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => c.Request("foo", null));
 
-            Assert.ThrowsAny<NATSConnectionClosedException>(() => s.NextMessage());
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => s.NextMessage());
 
-            Assert.ThrowsAny<NATSConnectionClosedException>(() => s.NextMessage(100));
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => s.NextMessage(100));
 
-            Assert.ThrowsAny<NATSConnectionClosedException>(() => s.Unsubscribe());
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => s.Unsubscribe());
 
-            Assert.ThrowsAny<NATSConnectionClosedException>(() => s.AutoUnsubscribe(1));
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => s.AutoUnsubscribe(1));
+            }
         }
 
         [Fact]
         public void TestConnectVerbose()
         {
+            using (new NATSServer())
+            {
+                Options o = utils.DefaultTestOptions;
+                o.Verbose = true;
 
-            Options o = utils.DefaultTestOptions;
-            o.Verbose = true;
-
-            IConnection c = new ConnectionFactory().CreateConnection(o);
-            c.Close();
+                IConnection c = new ConnectionFactory().CreateConnection(o);
+                c.Close();
+            }
         }
 
         //[Fact]
@@ -184,7 +183,8 @@ namespace NATSUnitTests
             AutoResetEvent recvCh1     = new AutoResetEvent(false);
             AutoResetEvent recvCh2     = new AutoResetEvent(false);
 
-            using (NATSServer s = utils.CreateServerWithConfig("auth_1222.conf"))
+            using (NATSServer s = utils.CreateServerWithConfig("auth_1222.conf"),
+                   def = new NATSServer())
             {
                 Options o = utils.DefaultTestOptions;
 
@@ -242,11 +242,7 @@ namespace NATSUnitTests
                     // due to resource constraints.  Allow time to start.
                     Thread.Sleep(1000);
 
-                    utils.StopDefaultServer();
-
-                    Thread.Sleep(1000);
-
-                    utils.StartDefaultServer();
+                    def.Bounce(1000);
 
                     Thread.Sleep(1000);
 
@@ -290,7 +286,7 @@ namespace NATSUnitTests
                     Assert.True(asyncErr1.WaitOne(3000));
                     Assert.True(asyncErr2.WaitOne(3000));
 
-                    utils.StopDefaultServer();
+                    def.Shutdown();
 
                     Thread.Sleep(1000);
                     closed.Reset();
@@ -300,7 +296,7 @@ namespace NATSUnitTests
                 }
 
 
-                if (dtime1 == orig || dtime2 == orig || rtime == orig || 
+                if (dtime1 == orig || dtime2 == orig || rtime == orig ||
                     atime1 == orig || atime2 == orig || ctime == orig)
                 {
                     Console.WriteLine("Error = callback didn't fire: {0}\n{1}\n{2}\n{3}\n{4}\n{5}\n",
@@ -308,71 +304,77 @@ namespace NATSUnitTests
                     throw new Exception("Callback didn't fire.");
                 }
 
-                if (rtime < dtime1 || dtime2 < rtime || ctime < atime2) 
+                if (rtime < dtime1 || dtime2 < rtime || ctime < atime2)
                 {
                     Console.WriteLine("Wrong callback order:\n" +
-                        "dtime1: {0}\n" + 
-                        "rtime:  {1}\n" + 
-                        "atime1: {2}\n" + 
+                        "dtime1: {0}\n" +
+                        "rtime:  {1}\n" +
+                        "atime1: {2}\n" +
                         "atime2: {3}\n" +
-                        "dtime2: {4}\n" + 
+                        "dtime2: {4}\n" +
                         "ctime:  {5}\n",
                         dtime1, rtime, atime1, atime2, dtime2, ctime);
                     throw new Exception("Invalid callback order.");
- 	            }
+                }
             }
         }
 
         [Fact]
         public void TestConnectionMemoryLeak()
         {
-            ConnectionFactory cf = new ConnectionFactory();
-            var sw = Stopwatch.StartNew();
-
-            GC.Collect();
-
-            long memStart = Process.GetCurrentProcess().PrivateMemorySize64;
-
-            while (sw.ElapsedMilliseconds < 10000)
+            using (new NATSServer())
             {
-                using (IConnection conn = cf.CreateConnection()) { }
+                ConnectionFactory cf = new ConnectionFactory();
+                var sw = Stopwatch.StartNew();
+
+                GC.Collect();
+
+                long memStart = Process.GetCurrentProcess().PrivateMemorySize64;
+
+                while (sw.ElapsedMilliseconds < 10000)
+                {
+                    using (IConnection conn = cf.CreateConnection()) { }
+                }
+
+                // allow the last dispose to finish.
+                Thread.Sleep(500);
+
+                GC.Collect();
+
+                double memGrowthPercent = 100 * (
+                    ((double)(Process.GetCurrentProcess().PrivateMemorySize64 - memStart))
+                        / (double)memStart);
+
+                Assert.True(memGrowthPercent < 20.0);
             }
-
-            // allow the last dispose to finish.
-            Thread.Sleep(500);
-
-            GC.Collect();
-
-            double memGrowthPercent = 100 * (
-                ((double)(Process.GetCurrentProcess().PrivateMemorySize64 - memStart))
-                    / (double)memStart);
-
-            Assert.True(memGrowthPercent < 20.0);
         }
 
         [Fact]
         public void TestConnectionCloseAndDispose()
         {
-            // test that dispose code works after a connection
-            // has been closed and cleaned up.
-            using (var c = utils.DefaultTestConnection)
+            using (new NATSServer())
             {
-                c.Close();
-                Thread.Sleep(500);
-            }
+                // test that dispose code works after a connection
+                // has been closed and cleaned up.
+                using (var c = utils.DefaultTestConnection)
+                {
+                    c.Close();
+                    Thread.Sleep(500);
+                }
 
-            // attempt to test that dispose works while the connection close
-            // has passed off work to cleanup the callback scheduler, etc.
-            using (var c = utils.DefaultTestConnection)
-            {
-                c.Close();
-                Thread.Sleep(500);
-            }
+                // attempt to test that dispose works while the connection close
+                // has passed off work to cleanup the callback scheduler, etc.
+                using (var c = utils.DefaultTestConnection)
+                {
+                    c.Close();
+                    Thread.Sleep(500);
+                }
 
-            // Check that dispose is idempotent.
-            using (var c = utils.DefaultTestConnection)
-            {
-                c.Dispose();
+                // Check that dispose is idempotent.
+                using (var c = utils.DefaultTestConnection)
+                {
+                    c.Dispose();
+                }
             }
         }
 

--- a/NATSUnitTests/UnitTestEncoding.cs
+++ b/NATSUnitTests/UnitTestEncoding.cs
@@ -20,7 +20,7 @@ namespace NATSUnitTests
         public TestEncoding()
         {
             UnitTestUtilities.CleanupExistingServers();
-            utils.StartDefaultServerAndDelay();
+            utils.StartDefaultServerAndVerify();
         }
 
         public void Dispose()

--- a/NATSUnitTests/UnitTestEncoding.cs
+++ b/NATSUnitTests/UnitTestEncoding.cs
@@ -28,6 +28,15 @@ namespace NATSUnitTests
             utils.StopDefaultServer();
         }
 
+        public IEncodedConnection DefaultEncodedConnection
+        {
+            get
+            {
+                return new ConnectionFactory().CreateEncodedConnection();
+            }
+        }
+
+
 #if NET45
         [Serializable]
         public class SerializationTestObj
@@ -62,7 +71,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestDefaultObjectSerialization()
         {
-            using (IEncodedConnection c = new ConnectionFactory().CreateEncodedConnection())
+            using (IEncodedConnection c = DefaultEncodedConnection)
             {
                 Object mu = new Object();
                 SerializationTestObj origObj = new SerializationTestObj();
@@ -95,7 +104,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestDefaultObjectSerialization()
         {
-            using (IEncodedConnection c = new ConnectionFactory().CreateEncodedConnection())
+            using (IEncodedConnection c = DefaultEncodedConnection)
             {
                 Assert.Throws<NATSException>(() => { c.Publish("foo", new Object()); });
                 Assert.Throws<NATSException>(() => { c.SubscribeAsync("foo", (obj, args)=>{}); });
@@ -130,7 +139,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestEncodedObjectSerization()
         {
-            using (IEncodedConnection c = new ConnectionFactory().CreateEncodedConnection())
+            using (IEncodedConnection c = DefaultEncodedConnection)
             {
                 c.OnDeserialize = jsonDeserializer;
                 c.OnSerialize = jsonSerializer;
@@ -168,7 +177,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestEncodedInvalidObjectSerialization()
         {
-            using (IEncodedConnection c = new ConnectionFactory().CreateEncodedConnection())
+            using (IEncodedConnection c = DefaultEncodedConnection)
             {
                 AutoResetEvent ev = new AutoResetEvent(false);
 
@@ -251,7 +260,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestEncodedSerizationOverrides()
         {
-            using (IEncodedConnection c = new ConnectionFactory().CreateEncodedConnection())
+            using (IEncodedConnection c = DefaultEncodedConnection)
             {
                 c.OnDeserialize = jsonDeserializer;
                 c.OnSerialize = jsonSerializer;
@@ -281,7 +290,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestEncodedObjectRequestReply()
         {
-            using (IEncodedConnection c = new ConnectionFactory().CreateEncodedConnection())
+            using (IEncodedConnection c = DefaultEncodedConnection)
             {
                 c.OnDeserialize = jsonDeserializer;
                 c.OnSerialize = jsonSerializer;

--- a/NATSUnitTests/UnitTestReconnect.cs
+++ b/NATSUnitTests/UnitTestReconnect.cs
@@ -40,7 +40,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestReconnectDisallowedFlags()
         {
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.Url = "nats://localhost:22222";
             opts.AllowReconnect = false;
 
@@ -70,7 +70,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestReconnectAllowedFlags()
         {
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.Url = "nats://localhost:22222";
             opts.MaxReconnect = 2;
             opts.ReconnectWait = 1000;
@@ -104,7 +104,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestBasicReconnectFunctionality()
         {
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.Url = "nats://localhost:22222";
             opts.MaxReconnect = 2;
             opts.ReconnectWait = 1000;
@@ -338,7 +338,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestClose()
         {
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.Url = "nats://localhost:22222";
             opts.AllowReconnect = true;
             opts.MaxReconnect = 60;
@@ -376,7 +376,7 @@ namespace NATSUnitTests
 
             IConnection c = null;
 
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.Url = "nats://localhost:22222";
             opts.AllowReconnect = true;
             opts.MaxReconnect = 10000;
@@ -449,7 +449,7 @@ namespace NATSUnitTests
             Object reconnectLock = new Object();
             bool   reconnected = false;
 
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.Verbose = true;
 
             opts.ReconnectedEventHandler += (sender, args) =>
@@ -503,7 +503,7 @@ namespace NATSUnitTests
             t.Start();
 
             byte[] payload = Encoding.UTF8.GetBytes("hello");
-            using (var c = new ConnectionFactory().CreateConnection())
+            using (var c = utils.DefaultTestConnection)
             {
                 connectedEv.Set();
 

--- a/NATSUnitTests/UnitTestSub.cs
+++ b/NATSUnitTests/UnitTestSub.cs
@@ -22,7 +22,7 @@ namespace NATSUnitTests
         public TestSubscriptions()
         {
             UnitTestUtilities.CleanupExistingServers();
-            utils.StartDefaultServerAndDelay();
+            utils.StartDefaultServerAndVerify();
         }
 
         public void Dispose()

--- a/NATSUnitTests/UnitTestSub.cs
+++ b/NATSUnitTests/UnitTestSub.cs
@@ -33,7 +33,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestServerAutoUnsub()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 long received = 0;
                 int max = 10;
@@ -66,7 +66,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestClientAutoUnsub()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 long received = 0;
                 int max = 10;
@@ -102,7 +102,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestCloseSubRelease()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (ISyncSubscription s = c.SubscribeSync("foo"))
                 {
@@ -125,7 +125,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestValidSubscriber()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (ISyncSubscription s = c.SubscribeSync("foo"))
                 {
@@ -149,7 +149,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestSlowSubscriber()
         {
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.SubChannelLength = 10;
 
             using (IConnection c = new ConnectionFactory().CreateConnection(opts))
@@ -183,7 +183,7 @@ namespace NATSUnitTests
         {
             ConditionalObj subCond = new ConditionalObj();
 
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.SubChannelLength = 100;
 
             using (IConnection c = new ConnectionFactory().CreateConnection(opts))
@@ -243,7 +243,7 @@ namespace NATSUnitTests
             IAsyncSubscription s;
 
 
-            Options opts = ConnectionFactory.GetDefaultOptions();
+            Options opts = utils.DefaultTestOptions;
             opts.SubChannelLength = 10;
 
             bool handledError = false;
@@ -315,7 +315,7 @@ namespace NATSUnitTests
         {
             Object waitCond = new Object();
 
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (IAsyncSubscription helper = c.SubscribeAsync("helper"),
                                           start = c.SubscribeAsync("start"))
@@ -363,7 +363,7 @@ namespace NATSUnitTests
             Object waitCond = new Object();
             int callbacks = 0;
 
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 using (IAsyncSubscription s = c.SubscribeAsync("foo"))
                 {
@@ -402,7 +402,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestNextMessageOnClosedSub()
         {
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 ISyncSubscription s = c.SubscribeSync("foo");
                 s.Unsubscribe();
@@ -428,7 +428,7 @@ namespace NATSUnitTests
 
             byte[] data = Encoding.UTF8.GetBytes("0123456789");
 
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 ISubscription s = c.SubscribeAsync("foo", (sender, args) =>
                 {
@@ -521,7 +521,7 @@ namespace NATSUnitTests
 
             byte[] data = Encoding.UTF8.GetBytes("0123456789");
 
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 ISyncSubscription s = c.SubscribeSync("foo");
 
@@ -567,7 +567,7 @@ namespace NATSUnitTests
 
             byte[] data = Encoding.UTF8.GetBytes("0123456789");
 
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 ISubscription s = c.SubscribeAsync("foo", (sender, args) => { });
 
@@ -597,7 +597,7 @@ namespace NATSUnitTests
 
             byte[] data = Encoding.UTF8.GetBytes("0123456789");
 
-            using (IConnection c = new ConnectionFactory().CreateConnection())
+            using (IConnection c = utils.DefaultTestConnection)
             {
                 ISyncSubscription s = c.SubscribeSync("foo");
 
@@ -623,7 +623,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestSubDelTaskCountBasic()
         {
-            var opts = ConnectionFactory.GetDefaultOptions();
+            var opts = utils.DefaultTestOptions;
 
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => { opts.SubscriberDeliveryTaskCount = -1; });
@@ -687,7 +687,7 @@ namespace NATSUnitTests
         public void TestSubDelTaskCountScaling()
         {
             int COUNT = 20000;
-            var opts = ConnectionFactory.GetDefaultOptions();
+            var opts = utils.DefaultTestOptions;
             opts.SubscriberDeliveryTaskCount = 20;
 
             using (IConnection c = new ConnectionFactory().CreateConnection(opts))
@@ -724,7 +724,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestSubDelTaskCountAutoUnsub()
         {
-            var opts = ConnectionFactory.GetDefaultOptions();
+            var opts = utils.DefaultTestOptions;
             opts.SubscriberDeliveryTaskCount = 2;
             using (IConnection c = new ConnectionFactory().CreateConnection(opts))
             {
@@ -764,7 +764,7 @@ namespace NATSUnitTests
             bool disconnected = false;
             AutoResetEvent reconnectEv = new AutoResetEvent(false);
 
-            var opts = ConnectionFactory.GetDefaultOptions();
+            var opts = utils.DefaultTestOptions;
             opts.SubscriberDeliveryTaskCount = 2;
             opts.DisconnectedEventHandler = (obj, args) => { disconnected = true;};
             opts.ReconnectedEventHandler = (obj, args) => { reconnectEv.Set(); };
@@ -813,7 +813,7 @@ namespace NATSUnitTests
         {
             AutoResetEvent errorEv = new AutoResetEvent(false);
 
-            var opts = ConnectionFactory.GetDefaultOptions();
+            var opts = utils.DefaultTestOptions;
             opts.SubscriberDeliveryTaskCount = 1;
             opts.SubChannelLength = 10;
 
@@ -846,7 +846,7 @@ namespace NATSUnitTests
         [Fact]
         public void TestSubDelTaskCountWithSyncSub()
         {
-            var opts = ConnectionFactory.GetDefaultOptions();
+            var opts = utils.DefaultTestOptions;
             opts.SubscriberDeliveryTaskCount = 1;
             using (IConnection c = new ConnectionFactory().CreateConnection(opts))
             {

--- a/NATSUnitTests/UnitTestTLS.cs
+++ b/NATSUnitTests/UnitTestTLS.cs
@@ -26,7 +26,7 @@ namespace NATSUnitTests
             try
             {
                 hitDisconnect = 0;
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = util.DefaultTestOptions;
                 opts.Url = url;
                 opts.DisconnectedEventHandler += handleDisconnect;
                 IConnection c = null;
@@ -99,7 +99,7 @@ namespace NATSUnitTests
         {
             using (NATSServer srv = util.CreateServerWithConfig("tls_1222_verify.conf"))
             {
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = util.DefaultTestOptions;
                 opts.Secure = true;
                 opts.Url = "nats://localhost:1222";
                 opts.TLSRemoteCertificationValidationCallback = verifyServerCert;
@@ -131,7 +131,7 @@ namespace NATSUnitTests
         {
             using (NATSServer srv = util.CreateServerWithConfig("tls_1222_verify.conf"))
             {
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = util.DefaultTestOptions;
                 opts.Secure = true;
                 opts.Url = "nats://localhost:1222";
                 opts.TLSRemoteCertificationValidationCallback = verifyServerCert;
@@ -149,7 +149,7 @@ namespace NATSUnitTests
         {
             using (NATSServer srv = util.CreateServerWithConfig("tls_1222_user.conf"))
             {
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = util.DefaultTestOptions;
                 opts.Secure = true;
                 opts.Url = "nats://username:BADDPASSOWRD@localhost:1222";
                 opts.TLSRemoteCertificationValidationCallback = verifyServerCert;
@@ -169,7 +169,7 @@ namespace NATSUnitTests
             {
                 // we can't call create secure connection w/ the certs setup as they are
                 // so we'll override the 
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = util.DefaultTestOptions;
                 opts.Secure = true;
                 opts.TLSRemoteCertificationValidationCallback = verifyServerCert;
                 opts.Url = "nats://localhost:1222";
@@ -196,7 +196,7 @@ namespace NATSUnitTests
             {
                 Thread.Sleep(1000);
 
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = util.DefaultTestOptions;
                 opts.Secure = true;
                 opts.NoRandomize = true;
                 opts.TLSRemoteCertificationValidationCallback = verifyServerCert;
@@ -241,7 +241,7 @@ namespace NATSUnitTests
                               s3 = util.CreateServerWithConfig("auth_tls_1224.conf"))
             {
 
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = util.DefaultTestOptions;
                 opts.Secure = true;
                 opts.NoRandomize = true;
                 opts.TLSRemoteCertificationValidationCallback = verifyServerCert;
@@ -276,7 +276,7 @@ namespace NATSUnitTests
                               s2 = util.CreateServerWithConfig("auth_tls_1224.conf"))
             {
 
-                Options opts = ConnectionFactory.GetDefaultOptions();
+                Options opts = util.DefaultTestOptions;
                 opts.Secure = true;
                 opts.NoRandomize = true;
                 opts.TLSRemoteCertificationValidationCallback = verifyServerCert;

--- a/NATSUnitTests/UnitTestUtilities.cs
+++ b/NATSUnitTests/UnitTestUtilities.cs
@@ -248,6 +248,8 @@ namespace NATSUnitTests
         internal static void CleanupExistingServers()
         {
             Process[] procs = Process.GetProcessesByName("gnatsd");
+            if (procs == null)
+                return;
 
             foreach (Process proc in procs)
             {
@@ -261,12 +263,14 @@ namespace NATSUnitTests
             // Let the OS cleanup.
             for (int i = 0; i < 10; i++)
             {
-                if (Process.GetProcessesByName("gnatsd").Length == 0)
-                {
+                procs = Process.GetProcessesByName("gnatsd");
+                if (procs == null || procs.Length == 0)
                     break;
-                }
+
                 Thread.Sleep(i * 250);
             }
+
+            Thread.Sleep(250);
         }
     }
 }

--- a/NATSUnitTests/UnitTestUtilities.cs
+++ b/NATSUnitTests/UnitTestUtilities.cs
@@ -247,16 +247,26 @@ namespace NATSUnitTests
 
         internal static void CleanupExistingServers()
         {
-            try
-            {
-                Process[] procs = Process.GetProcessesByName("gnatsd");
+            Process[] procs = Process.GetProcessesByName("gnatsd");
 
-                foreach (Process proc in procs)
+            foreach (Process proc in procs)
+            {
+                try
                 {
                     proc.Kill();
                 }
+                catch (Exception) { } // ignore
             }
-            catch (Exception) { } // ignore
+
+            // Let the OS cleanup.
+            for (int i = 0; i < 10; i++)
+            {
+                if (Process.GetProcessesByName("gnatsd").Length == 0)
+                {
+                    break;
+                }
+                Thread.Sleep(i * 250);
+            }
         }
     }
 }

--- a/NATSUnitTests/UnitTestUtilities.cs
+++ b/NATSUnitTests/UnitTestUtilities.cs
@@ -162,6 +162,24 @@ namespace NATSUnitTests
             return Path.Combine(runningDirectory, "config");
         }
 
+        public Options DefaultTestOptions
+        {
+            get
+            {
+                var opts = ConnectionFactory.GetDefaultOptions();
+                opts.Timeout = 10000;
+                return opts;
+            }
+        }
+
+        public IConnection DefaultTestConnection
+        {
+            get
+            {
+                return new ConnectionFactory().CreateConnection(DefaultTestOptions);
+            }
+        }
+
         public void StartDefaultServer()
         {
             lock (mu)


### PR DESCRIPTION
Various fixes, updates to fix flappers in the unit tests.
- Ensure each test starts and stops the NATS server if it uses one.  While Xunit allows one to disable parallel execution of tests, it still seems to load the different test classes with some overlap.  This caused the code that cleaned up, started, or stopped NATS servers when test class objects were loaded or disposed of to be occasionally invoked at times that would kill servers in use, causing tests to fail.  This happened more often in stressed environments, such as AppVeyor.
- Create and use general test options to tweak for various environments.
- Check for server startup rather than simply sleep, so that tests can proceed sooner.
- General cleanup, and removed code that ended up duplicating functionality available in .NET

Resolves #131
