### PR TITLE
Fix flapping memory growth test

### DIFF
--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -337,7 +337,7 @@ namespace NATSUnitTests
                 }
 
                 // allow the last dispose to finish.
-                Thread.Sleep(500);
+                Thread.Sleep(2000);
 
                 GC.Collect();
 
@@ -345,7 +345,7 @@ namespace NATSUnitTests
                     ((double)(Process.GetCurrentProcess().PrivateMemorySize64 - memStart))
                         / (double)memStart);
 
-                Assert.True(memGrowthPercent < 20.0);
+                Assert.True(memGrowthPercent < 30.0);
             }
         }
 


### PR DESCRIPTION
* Passes locally 100% of the time, fails freqently on AppVeyor