### PR TITLE
Set the subscriber message delivery task to long running.

### DIFF
--- a/NATS.Client/AsyncSub.cs
+++ b/NATS.Client/AsyncSub.cs
@@ -81,7 +81,8 @@ namespace NATS.Client
         {
             if (ownsChannel && msgFeeder == null)
             {
-                msgFeeder = new Task(() => { conn.deliverMsgs(mch); });
+                msgFeeder = new Task(() => { conn.deliverMsgs(mch); },
+                    TaskCreationOptions.LongRunning);
                 msgFeeder.Start();
             }
             started = true;


### PR DESCRIPTION
This helps ensure the message delivery task gets scheduled with enough CPU time.  Since the SubscriberDeliveryTaskCount option is available, this can be specified as long running.