### PR TITLE
Fix pool shuffling

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -1691,9 +1691,8 @@ namespace NATS.Client
                     // not the entire pool. We want to preserve the pool's
                     // order up to this point (this would otherwise be 
                     // problematic for the (re)connect loop).
-                    var rnd = new Random();
-                    servers = info.connectURLs.OrderBy
-                        (x => rnd.Next()).ToArray();
+                    servers = (string[])info.connectURLs.Clone();
+                    ServerPool.shuffle<string>(servers);
                 }
                 srvPool.Add(servers, true);
             }

--- a/NATS.Client/ServerPool.cs
+++ b/NATS.Client/ServerPool.cs
@@ -220,22 +220,34 @@ namespace NATS.Client
             }
         }
 
+        // Convenience method to shuffle a list.  The list passed
+        // is modified.
+        internal static void shuffle<T>(IList<T> list)
+        {
+            if (list == null)
+                return;
+
+            int n = list.Count;
+            if (n == 1)
+                return;
+
+            Random r = new Random();
+            while (n > 1)
+            {
+                n--;
+                int k = r.Next(n + 1);
+                var value = list[k];
+                list[k] = list[n];
+                list[n] = value;
+            }
+        }
+
         private void shuffle()
         {
-            Random r = new Random();
-
             lock (poolLock)
             {
                 var servers = sList.ToArray();
-                int n = servers.Length;
-                while (n > 1)
-                {
-                    n--;
-                    int k = r.Next(n + 1);
-                    var value = servers[k];
-                    servers[k] = servers[n];
-                    servers[n] = value;
-                }
+                shuffle(servers);
 
                 sList.Clear();
                 foreach (Srv s in servers)

--- a/NATS.Client/ServerPool.cs
+++ b/NATS.Client/ServerPool.cs
@@ -64,7 +64,7 @@ namespace NATS.Client
                 Add(opts.Servers, false);
 
                 if (!opts.NoRandomize)
-                    Shuffle();
+                    shuffle();
             }
 
             if (!string.IsNullOrWhiteSpace(opts.Url))
@@ -191,44 +191,36 @@ namespace NATS.Client
             return rv.ToArray();
         }
 
-        private bool add(string s, bool isImplicit)
+        private void add(string s, bool isImplicit)
         {
-            return add(new Srv(s, isImplicit));
+            add(new Srv(s, isImplicit));
         }
 
         // returns true if it modified the pool, false if
         // the url already exists.
-        private bool add(Srv s)
+        private void add(Srv s)
         {
             lock (poolLock)
             {
                 if (sList.Contains(s, duplicateSrvCheck))
-                    return false;
+                    return;
 
                 sList.AddLast(s);
-                return true;
             }
         }
 
-        internal bool Add(string[] urls, bool isImplicit)
+        internal void Add(string[] urls, bool isImplicit)
         {
             if (urls == null)
-                return false;
-
-            bool modified = false;
+                return;
 
             foreach (string s in urls)
             {
-                if (add(s, isImplicit))
-                {
-                    modified = true;
-                }
+                add(s, isImplicit);
             }
-
-            return modified;
         }
 
-        internal void Shuffle()
+        private void shuffle()
         {
             Random r = new Random();
 

--- a/NATSUnitTests/UnitTestBasic.cs
+++ b/NATSUnitTests/UnitTestBasic.cs
@@ -1125,7 +1125,14 @@ namespace NATSUnitTests
                 // Create a new connection to start from scratch.
                 c.Close();
                 c = new ConnectionFactory().CreateConnection(opts);
-                Assert.True(c.Servers.Length ==7);
+                for (int i = 0; i < 5; i++)
+                {
+                    Thread.Sleep(500 * i);
+
+                    if (c.Servers.Length == 7)
+                        break;
+                }
+                Assert.True(c.Servers.Length ==7, "Server count should be 7, is: " + c.Servers.Length);
 
                 // Sufficiently test to ensure we don't hit a random false positive
                 // - avoid flappers.

--- a/NATSUnitTests/UnitTestBasic.cs
+++ b/NATSUnitTests/UnitTestBasic.cs
@@ -1104,7 +1104,7 @@ namespace NATSUnitTests
 
             // wait until the servers are routed and the conn has the updated
             // server list.
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < 10; i++)
             {
                 Thread.Sleep(500 * i);
 


### PR DESCRIPTION
When connecting to a server, the received INFO may contain an array
of URLs. The current code was adding those and then shuffling the
entire pool (if NoRandomize is false). This is wrong since the
connect (and reconnect) loop would then potentially skip never
tried servers and try again servers that had just failed.

* Only randomize discovered servers
* Refactored the add APIs in ServerPool (the return value is no longer needed)

Resolves #144 