### PR TITLE
Cleanup unnecessary using directives.

### DIFF
--- a/NATS.Client/ConnectionFactory.cs
+++ b/NATS.Client/ConnectionFactory.cs
@@ -1,11 +1,5 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace NATS.Client
 {
     /// <summary>

--- a/NATS.Client/EncodedConn.cs
+++ b/NATS.Client/EncodedConn.cs
@@ -1,13 +1,9 @@
 ﻿
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Json;
 #if NET45
+using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
 // disable XML comment warnings

--- a/NATS.Client/Exceptions.cs
+++ b/NATS.Client/Exceptions.cs
@@ -1,14 +1,6 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.IO;
-
 
 namespace NATS.Client
 {

--- a/NATS.Client/ISubscription.cs
+++ b/NATS.Client/ISubscription.cs
@@ -1,10 +1,5 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace NATS.Client
 {
     /// <summary>

--- a/NATS.Client/ISyncSubscription.cs
+++ b/NATS.Client/ISyncSubscription.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace NATS.Client
 {

--- a/NATS.Client/NATS.cs
+++ b/NATS.Client/NATS.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 /*! \mainpage %NATS .NET client.
  *

--- a/NATS.Client/NUID.cs
+++ b/NATS.Client/NUID.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NATS.Client
 {

--- a/NATS.Client/Parser.cs
+++ b/NATS.Client/Parser.cs
@@ -1,12 +1,5 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
      
 namespace NATS.Client

--- a/NATS.Client/ServerPool.cs
+++ b/NATS.Client/ServerPool.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 
 namespace NATS.Client
 {

--- a/NATS.Client/Statistics.cs
+++ b/NATS.Client/Statistics.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright 2015 Apcera Inc. All rights reserved.
 
-using System;
 
 // disable XML comment warnings
 #pragma warning disable 1591

--- a/NATSUnitTests/UnitTestUtilities.cs
+++ b/NATSUnitTests/UnitTestUtilities.cs
@@ -3,10 +3,11 @@
 using System;
 using System.Threading;
 using System.Diagnostics;
-using System.Reflection;
 using System.IO;
-using Xunit;
 using NATS.Client;
+#if NET45
+using System.Reflection;
+#endif
 
 namespace NATSUnitTests
 {

--- a/examples/Benchmark/Benchmark.cs
+++ b/examples/Benchmark/Benchmark.cs
@@ -3,8 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using NATS.Client;
 using System.Diagnostics;

--- a/examples/Benchmark/Properties/AssemblyInfo.cs
+++ b/examples/Benchmark/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright 2016 Apcera Inc. All rights reserved.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 


### PR DESCRIPTION
No functional change. Some using directives were automatically generated by the editor or are no longer necessary as the client code changed, was refactored, etc.  They can be removed.

Resoves #146 