### PR TITLE
Fix a condition where a request timeout may not be honored.

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -118,6 +118,9 @@ namespace NATS.Client
 
         static readonly int REQ_CANCEL_IVL = 100;
 
+        // 60 second default flush timeout
+        static readonly int DEFAULT_FLUSH_TIMEOUT = 60000;
+
         TCPConnection conn = new TCPConnection();
 
         SubChannelPool subChannelPool = null;
@@ -1878,7 +1881,7 @@ namespace NATS.Client
             s.AutoUnsubscribe(1);
 
             publish(subject, inbox, data);
-            Flush();
+            Flush(timeout > 0 ? timeout : DEFAULT_FLUSH_TIMEOUT);
             m = s.NextMessage(timeout);
             s.unsubscribe(false);
 
@@ -1934,7 +1937,7 @@ namespace NATS.Client
                 s.AutoUnsubscribe(1);
 
                 publish(subject, inbox, data);
-                Flush();
+                Flush(timeout > 0 ? timeout: DEFAULT_FLUSH_TIMEOUT);
 
                 int timeRemaining = timeout;
 
@@ -2317,8 +2320,7 @@ namespace NATS.Client
         /// </summary>
         public void Flush()
         {
-            // 60 second default.
-            Flush(60000);
+            Flush(DEFAULT_FLUSH_TIMEOUT);
         }
 
         // resendSubscriptions will send our subscription state back to the


### PR DESCRIPTION
Resolves #150

The request API invokes Flush() to reduce latency, which has a 60s default.  In certain error conditions, the flush can timeout inside the request, resulting in a different timeout than the one specified.  This fix makes the request API behave better by using the request timeout in the flush.

* Theoretically, the actual timeout could approach 2x the specified timeout, but this is better than 60s if small timeouts are specified.
* Added specific RequestAsync() timeout tests.
* Added additional tests for Flush().