### PR TITLE
Implements ServerDiscoveredEventHandler from #159

### DIFF
--- a/NATS.Client/Options.cs
+++ b/NATS.Client/Options.cs
@@ -35,6 +35,12 @@ namespace NATS.Client
         public EventHandler<ConnEventArgs> ClosedEventHandler = null;
 
         /// <summary>
+        /// Represents the method that will handle an event raised
+        /// whenever a new server has joined the cluster.
+        /// </summary>
+        public EventHandler<ConnEventArgs> ServerDiscoveredEventHandler = null;
+
+        /// <summary>
         /// Represents the method that will handle an event raised 
         /// when a connection has been disconnected from a server.
         /// </summary>
@@ -71,6 +77,7 @@ namespace NATS.Client
             allowReconnect = o.allowReconnect;
             AsyncErrorEventHandler = o.AsyncErrorEventHandler;
             ClosedEventHandler = o.ClosedEventHandler;
+            ServerDiscoveredEventHandler = o.ServerDiscoveredEventHandler;
             DisconnectedEventHandler = o.DisconnectedEventHandler;
             maxPingsOut = o.maxPingsOut;
             maxReconnect = o.maxReconnect;

--- a/NATS.Client/ServerPool.cs
+++ b/NATS.Client/ServerPool.cs
@@ -189,33 +189,42 @@ namespace NATS.Client
             return rv.ToArray();
         }
 
-        private void add(string s, bool isImplicit)
+        // returns true if it modified the pool, false if
+        // the url already exists.
+        private bool add(string s, bool isImplicit)
         {
-            add(new Srv(s, isImplicit));
+            return add(new Srv(s, isImplicit));
         }
 
         // returns true if it modified the pool, false if
         // the url already exists.
-        private void add(Srv s)
+        private bool add(Srv s)
         {
             lock (poolLock)
             {
                 if (sList.Contains(s, duplicateSrvCheck))
-                    return;
+                    return false;
 
                 sList.AddLast(s);
+
+                return true;
             }
         }
 
-        internal void Add(string[] urls, bool isImplicit)
+        // returns true if any of the urls were added to the pool,
+        // false if they all already existed
+        internal bool Add(string[] urls, bool isImplicit)
         {
             if (urls == null)
-                return;
+                return false;
 
+            bool didAdd = false;
             foreach (string s in urls)
             {
-                add(s, isImplicit);
+                didAdd |= add(s, isImplicit);
             }
+
+            return didAdd;
         }
 
         // Convenience method to shuffle a list.  The list passed

--- a/NATSUnitTests/UnitTestCluster.cs
+++ b/NATSUnitTests/UnitTestCluster.cs
@@ -201,8 +201,15 @@ namespace NATSUnitTests
                     // ...then while connected, start up a second server...
                     using (NATSServer ns2 = utils.CreateServerWithArgs(secondClusterMemberArgs))
                     {
-                        // ...waiting 5 seconds for the second server to start...
-                        Thread.Sleep(5000);
+                        // ...waiting up to 30 seconds for the second server to start...
+                        for (int ii = 0; ii < 6; ii++)
+                        {
+                            Thread.Sleep(5000);
+
+                            // ...taking an early out if we detected the startup...
+                            if (serverDiscoveredCalled)
+                                break;
+                        }
 
                         // ...and by then we should have received notification of
                         // its awakening.

--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -159,6 +159,27 @@ namespace NATSUnitTests
             }
         }
 
+        [Fact]
+        public void TestServerDiscoveredHandlerNotCalledOnConnect()
+        {
+            using (new NATSServer())
+            {
+                Options o = utils.DefaultTestOptions;
+
+                bool serverDiscoveredCalled = false;
+
+                o.ServerDiscoveredEventHandler += (sender, e) =>
+                {
+                    serverDiscoveredCalled = true;
+                };
+
+                IConnection c = new ConnectionFactory().CreateConnection(o);
+                c.Close();
+
+                Assert.False(serverDiscoveredCalled);
+            }
+        }
+
         //[Fact]
         // This test works locally, but fails in AppVeyor some of the time
         // TODO:  Work to identify why this happens...

--- a/README.md
+++ b/README.md
@@ -427,6 +427,12 @@ Other events can be assigned delegate methods through the options object.
                 Console.WriteLine("   Subject: " + args.Subscription.Subject);
             };
 
+            opts.ServerDiscoveredEventHandler += (sender, args) =>
+            {
+                Console.WriteLine("A new server has joined the cluster:");
+                Console.WriteLine("    " + String.Join(", ", args.Conn.DiscoveredServers));
+            };
+
             opts.ClosedEventHandler += (sender, args) =>
             {
                 Console.WriteLine("Connection Closed: ");


### PR DESCRIPTION
ServerPool.add matches its description and returns a boolean indicating if the server url
is new for the pool. Connection.processInfoArgs uses this to signal on the new event if and
only if it has been asked to notify on server discovery. The initial connect path does not enable
that behavior, but the processAsyncInfo path does enable it, matching the behavior of the
golang client https://github.com/nats-io/go-nats/pull/282