### PR TITLE
Fix weak reply name for Request() call.

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -53,8 +53,6 @@ namespace NATS.Client
         // .NET 4.0.
         readonly internal object mu = new Object(); 
 
-        private Random r = null;
-
         Options opts = new Options();
 
         // returns the options used to create this connection.
@@ -2099,14 +2097,7 @@ namespace NATS.Client
 
         public string NewInbox()
         {
-            if (r == null)
-                r = new Random();
-
-            byte[] buf = new byte[13];
-
-            r.NextBytes(buf);
-
-            return IC.inboxPrefix + BitConverter.ToString(buf).Replace("-","");
+            return IC.inboxPrefix + Guid.NewGuid().ToString("N").ToUpperInvariant();
         }
 
         internal void sendSubscriptionMessage(AsyncSubscription s)

--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -51,7 +51,9 @@ namespace NATS.Client
 
         // NOTE: We aren't using Mutex here to support enterprises using
         // .NET 4.0.
-        readonly internal object mu = new Object(); 
+        readonly internal object mu = new Object();
+
+		private Random r = null;
 
         Options opts = new Options();
 
@@ -2097,7 +2099,14 @@ namespace NATS.Client
 
         public string NewInbox()
         {
-            return IC.inboxPrefix + Guid.NewGuid().ToString("N").ToUpperInvariant();
+			if (r == null)
+				r = new Random(Guid.NewGuid().GetHashCode());
+
+			byte[] buf = new byte[13];
+
+			r.NextBytes(buf);
+
+			return IC.inboxPrefix + BitConverter.ToString(buf).Replace("-", "");
         }
 
         internal void sendSubscriptionMessage(AsyncSubscription s)

--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -53,7 +53,7 @@ namespace NATS.Client
         // .NET 4.0.
         readonly internal object mu = new Object();
 
-		private Random r = null;
+        private Random r = null;
 
         Options opts = new Options();
 
@@ -2099,14 +2099,14 @@ namespace NATS.Client
 
         public string NewInbox()
         {
-			if (r == null)
-				r = new Random(Guid.NewGuid().GetHashCode());
+            if (r == null)
+                r = new Random(Guid.NewGuid().GetHashCode());
 
-			byte[] buf = new byte[13];
+            byte[] buf = new byte[13];
 
-			r.NextBytes(buf);
+            r.NextBytes(buf);
 
-			return IC.inboxPrefix + BitConverter.ToString(buf).Replace("-", "");
+            return IC.inboxPrefix + BitConverter.ToString(buf).Replace("-", "");
         }
 
         internal void sendSubscriptionMessage(AsyncSubscription s)

--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -413,6 +413,24 @@ namespace NATSUnitTests
             }
         }
 
+        [Fact]
+        public void TestGenerateUniqueInboxNames()
+        {
+            using (new NATSServer())
+            {
+                string lastInboxName = null;
+
+                for (var i = 0; i < 1000; i++)
+                {
+                    IConnection c = utils.DefaultTestConnection;
+                    var inboxName = c.NewInbox();
+                    c.Close();
+                    Assert.NotEqual(inboxName, lastInboxName);
+                    lastInboxName = inboxName;
+                }
+            }
+        }
+
         /// NOT IMPLEMENTED:
         /// TestServerSecureConnections
         /// TestErrOnConnectAndDeadlock


### PR DESCRIPTION
Current implementation of NewInbox() could generate identical names when several Request() calls could be done from different threads at the close time.
The problem is that Random() uses Environment.TickCount as a seed. When program makes several Request() calls in the same system tick (500 ms), the several Random().NextBytes() calls will generate identical inbox names for reply for different requests. In that case both requests will get the first server response.
To solve it I suggest to use more strongly generator like Guid.NextGuid() for inbox name.