### PR TITLE
Fix problem with parsing server url.

### DIFF
--- a/NATS.Client/Srv.cs
+++ b/NATS.Client/Srv.cs
@@ -19,7 +19,7 @@ namespace NATS.Client
         internal Srv(string urlString)
         {
             // allow for host:port, without the prefix.
-            if (urlString.ToLower().StartsWith("nats") == false)
+            if (urlString.ToLower().StartsWith("nats://") == false)
                 urlString = "nats://" + urlString;
 
             url = new Uri(urlString);


### PR DESCRIPTION
When passed urlString starts with ‘nats’ (like ‘nats.domain.com’ or 'natsserver.company.com') the protocol supplement will be skipped and connection will fail.