### PR TITLE
Channel<T> improvements

### DIFF
--- a/NATS.Client/AsyncSub.cs
+++ b/NATS.Client/AsyncSub.cs
@@ -23,7 +23,10 @@ namespace NATS.Client
             mch = conn.getMessageChannel();
             if ((ownsChannel = (mch == null)))
             {
-                mch = new Channel<Msg>();
+                mch = new Channel<Msg>()
+                {
+                    Name = subject + (String.IsNullOrWhiteSpace(queue) ? "" : " (queue: " + queue + ")"),
+                };
             }
         }
 

--- a/NATS.Client/Channel.cs
+++ b/NATS.Client/Channel.cs
@@ -1,11 +1,72 @@
 ﻿// Copyright 2015-2017 Apcera Inc. All rights reserved.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 
 namespace NATS.Client
 {
+    // Provides a Channel<T> implementation that only allows a single call to 'get'
+    // Used for ping-pong
+    internal sealed class SingleUseChannel<T>
+    {
+        static readonly ConcurrentBag<SingleUseChannel<T>> Channels = new ConcurrentBag<SingleUseChannel<T>>();
+
+        public static SingleUseChannel<T> GetOrCreate()
+        {
+            SingleUseChannel<T> item;
+            if (Channels.TryTake(out item))
+            {
+                return item;
+            }
+
+            return new SingleUseChannel<T>();
+        }
+
+        public static void Return(SingleUseChannel<T> ch)
+        {
+            ch.reset();
+            if (Channels.Count < 1024) Channels.Add(ch);
+        }
+
+        bool hasValue = false;
+        T actualValue;
+        readonly ManualResetEventSlim e = new ManualResetEventSlim();
+
+        internal T get(int timeout)
+        {
+            while (!hasValue)
+            {
+                if (timeout < 0)
+                {
+                    e.Wait();
+                }
+                else
+                {
+                    if (!e.Wait(timeout))
+                        throw new NATSTimeoutException();
+                }
+            }
+
+            return actualValue;
+        }
+
+        internal void add(T value)
+        {
+            actualValue = value;
+            hasValue = true;
+            e.Set();
+        }
+
+        internal void reset()
+        {
+            hasValue = false;
+            e.Reset();
+            actualValue = default(T);
+        }
+    }
+
     // This channel class, really a blocking queue, is named the way it is
     // so the code more closely reads with GO.  We implement our own channels 
     // to be lightweight and performant - other concurrent classes do the
@@ -16,101 +77,204 @@ namespace NATS.Client
         readonly Object   qLock = new Object();
 
         bool   finished = false;
-        
+
+        public string Name { get; set; }
+
         internal Channel()
         {
+            Name = "Unnamed " + this.GetHashCode();
             q = new Queue<T>(1024);
         }
 
         internal Channel(int initialCapacity)
         {
+            Name = "Unnamed " + this.GetHashCode();
             q = new Queue<T>(initialCapacity);
         }
 
         internal T get(int timeout)
         {
-            T rv = default(T);
-
             Monitor.Enter(qLock);
-
-            if (finished)
+            try
             {
-                Monitor.Exit(qLock);
-                return default(T);
-            }
-
-            if (q.Count > 0)
-            {
-                rv = q.Dequeue();
-                Monitor.Exit(qLock);
-                return rv;
-            }
-
-            // if we had a *rare* spurious wakeup from Monitor.Wait(),
-            // we could have an empty queue.  Protect this case by
-            // rechecking in a loop.  This should be very rare, 
-            // so keep it simple and just wait again.  This may result in 
-            // a longer timeout that specified.
-            do
-            {
-                if (timeout < 0)
-                {
-                    Monitor.Wait(qLock);
-                }
-                else
-                {
-                    if (Monitor.Wait(qLock, timeout) == false)
-                    {
-                        // Unlock before exiting.
-                        Monitor.Exit(qLock);
-                        throw new NATSTimeoutException();
-                    }
-                }
-
-                // we waited, but are woken up by a finish...
                 if (finished)
-                    break;
+                {
+                    return default(T);
+                }
 
-                // we can have an empty queue if there was a spurious wakeup.
                 if (q.Count > 0)
                 {
-                    rv = q.Dequeue();
-                    break;
+                    return q.Dequeue();
                 }
 
-            } while (true);
+                // if we had a *rare* spurious wakeup from Monitor.Wait(),
+                // we could have an empty queue.  Protect this case by
+                // rechecking in a loop.  This should be very rare, 
+                // so keep it simple and just wait again.  This may result in 
+                // a longer timeout that specified.
+                do
+                {
+                    if (timeout < 0)
+                    {
+                        Monitor.Wait(qLock);
+                    }
+                    else
+                    {
+                        if (Monitor.Wait(qLock, timeout) == false)
+                        {
+                            throw new NATSTimeoutException();
+                        }
+                    }
 
-            Monitor.Exit(qLock);
+                    // we waited, but are woken up by a finish...
+                    if (finished)
+                        return default(T);
 
-            return rv;
-
+                    // we can have an empty queue if there was a spurious wakeup.
+                    if (q.Count > 0)
+                    {
+                        return q.Dequeue();
+                    }
+                } while (true);
+            }
+            finally
+            {
+                Monitor.Exit(qLock);
+            }
         } // get
-        
+
+        // Gets all available items in the queue, up to the size of the input buffer.
+        // Returns the number of items delivered into the buffer.
+        internal int get(int timeout, T[] buffer)
+        {
+            if (buffer.Length < 1) throw new ArgumentException();
+
+            int delivered = 0;
+            Monitor.Enter(qLock);
+            try
+            {
+                if (finished)
+                {
+                    return 0;
+                }
+
+                if (q.Count > 0)
+                {
+                    for (int ii = 0; ii < buffer.Length && q.Count > 0; ++ii)
+                    {
+                        buffer[ii] = q.Dequeue();
+                        delivered++;
+                    }
+
+                    return delivered;
+                }
+
+                // if we had a *rare* spurious wakeup from Monitor.Wait(),
+                // we could have an empty queue.  Protect this case by
+                // rechecking in a loop.  This should be very rare, 
+                // so keep it simple and just wait again.  This may result in 
+                // a longer timeout that specified.
+                do
+                {
+                    if (timeout < 0)
+                    {
+                        Monitor.Wait(qLock);
+                    }
+                    else
+                    {
+                        if (Monitor.Wait(qLock, timeout) == false)
+                        {
+                            throw new NATSTimeoutException();
+                        }
+                    }
+
+                    // we waited, but are woken up by a finish...
+                    if (finished)
+                        return 0;
+
+                    // we can have an empty queue if there was a spurious wakeup.
+                    if (q.Count > 0)
+                    {
+                        for (int ii = 0; ii < buffer.Length && q.Count > 0; ++ii)
+                        {
+                            buffer[ii] = q.Dequeue();
+                            delivered++;
+                        }
+
+                        return delivered;
+                    }
+
+                } while (true);
+            }
+            finally
+            {
+                Monitor.Exit(qLock);
+            }
+        } // get
+
         internal void add(T item)
         {
             Monitor.Enter(qLock);
-
-            q.Enqueue(item);
-
-            // if the queue count was previously zero, we were
-            // waiting, so signal.
-            if (q.Count <= 1)
+            try
             {
-                Monitor.Pulse(qLock);
-            }
+                q.Enqueue(item);
 
-            Monitor.Exit(qLock);
+                // if the queue count was previously zero, we were
+                // waiting, so signal.
+                if (q.Count <= 1)
+                {
+                    Monitor.Pulse(qLock);
+                }
+            }
+            finally
+            {
+                Monitor.Exit(qLock);
+            }
+        }
+
+        // attempt to add an item, if-and-only-if the queue has not
+        // exceeded the given upper bound.
+        internal bool tryAdd(T item, int upperBound)
+        {
+            Monitor.Enter(qLock);
+            try
+            {
+                if (q.Count >= upperBound)
+                    return false;
+
+                q.Enqueue(item);
+
+                // if the queue count was previously zero, we were
+                // waiting, so signal.
+                if (q.Count <= 1)
+                {
+                    Monitor.Pulse(qLock);
+                }
+
+                return true;
+            }
+            finally
+            {
+                Monitor.Exit(qLock);
+            }
         }
 
         internal void close()
         {
             Monitor.Enter(qLock);
+            try
+            {
 
-            finished = true;
-            Monitor.Pulse(qLock);
-            q.Clear();
+                finished = true;
 
-            Monitor.Exit(qLock);
+                q.Clear();
+
+                Monitor.Pulse(qLock);
+            }
+            finally
+            {
+                Monitor.Exit(qLock);
+            }
         }
 
         internal int Count

--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -1438,8 +1438,14 @@ namespace NATS.Client
         // It is used to deliver messages to asynchronous subscribers.
         internal void deliverMsgs(Channel<Msg> ch)
         {
+            int batchSize;
+            lock (mu)
+            {
+                batchSize = opts.subscriptionBatchSize;
+            }
+
             // dispatch buffer
-            Msg[] mm = new Msg[64];
+            Msg[] mm = new Msg[batchSize];
 
             while (true)
             {

--- a/NATS.Client/Options.cs
+++ b/NATS.Client/Options.cs
@@ -436,6 +436,7 @@ namespace NATS.Client
             sb.AppendFormat("User={0};", User);
             sb.AppendFormat("Token={0};", Token);
             sb.AppendFormat("SubscriberDeliveryTaskCount={0};", SubscriberDeliveryTaskCount);
+            sb.AppendFormat("SubscriptionBatchSize={0};", SubscriptionBatchSize);
 
             if (Servers == null)
             {

--- a/NATS.Client/Options.cs
+++ b/NATS.Client/Options.cs
@@ -63,6 +63,9 @@ namespace NATS.Client
         internal int subChanLen = 65536;
         internal int subscriberDeliveryTaskCount = 0;
 
+        // Must be greater than 0.
+        internal int subscriptionBatchSize = 64;
+
         internal string user;
         internal string password;
         internal string token;
@@ -98,6 +101,7 @@ namespace NATS.Client
             token = o.token;
             verbose = o.verbose;
             subscriberDeliveryTaskCount = o.subscriberDeliveryTaskCount;
+            subscriptionBatchSize = o.subscriptionBatchSize;
             
             if (o.servers != null)
             {
@@ -370,6 +374,30 @@ namespace NATS.Client
                     throw new ArgumentOutOfRangeException("SubscriberDeliveryTaskCount must be 0 or greater.");
                 }
                 subscriberDeliveryTaskCount = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the batch size for calling subscription handlers.
+        /// </summary>
+        /// <remarks>
+        /// When delivering messages to the subscriber, the batch size determines
+        /// how many messages could be retrieved from the internal subscription
+        /// queue at one time. This can allow higher performance from a single
+        /// subscriber by avoiding the locking overhead of one-at-a-time
+        /// retrieval from the queue.
+        /// </remarks>
+        public int SubscriptionBatchSize
+        {
+            get { return subscriptionBatchSize; }
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException("value", "Subscription batch size must be greater than 0");
+                }
+
+                subscriptionBatchSize = value;
             }
         }
 

--- a/NATS.Client/SyncSub.cs
+++ b/NATS.Client/SyncSub.cs
@@ -3,6 +3,8 @@
 // disable XM comment warnings
 #pragma warning disable 1591
 
+using System;
+
 namespace NATS.Client
 {
     public sealed class SyncSubscription : Subscription, ISyncSubscription, ISubscription 
@@ -10,7 +12,10 @@ namespace NATS.Client
         internal SyncSubscription(Connection conn, string subject, string queue)
             : base(conn, subject, queue)
         {
-            mch = new Channel<Msg>();
+            mch = new Channel<Msg>()
+            {
+                Name = subject + (String.IsNullOrWhiteSpace(queue) ? "" : " (queue: " + queue + ")"),
+            };
         }
 
         public Msg NextMessage()

--- a/NATSUnitTests/UnitTestBasic.cs
+++ b/NATSUnitTests/UnitTestBasic.cs
@@ -573,11 +573,11 @@ namespace NATSUnitTests
                     var cts = new CancellationTokenSource();
                     var ct = cts.Token;
                     cts.Cancel();
-                    await Assert.ThrowsAsync<TaskCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
 
                     // test cancellation
                     cts = new CancellationTokenSource();
-                    var ocex = Assert.ThrowsAsync<OperationCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
+                    var ocex = Assert.ThrowsAnyAsync<OperationCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
                     Thread.Sleep(2000);
                     cts.Cancel();
                     await ocex;
@@ -590,7 +590,7 @@ namespace NATSUnitTests
 
                         // test cancellation with a subscriber
                         cts = new CancellationTokenSource();
-                        ocex = Assert.ThrowsAsync<OperationCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
+                        ocex = Assert.ThrowsAnyAsync<OperationCanceledException>(() => { return c.RequestAsync("foo", null, cts.Token); });
                         Thread.Sleep(responseDelay / 2);
                         cts.Cancel();
                         await ocex;
@@ -633,7 +633,11 @@ namespace NATSUnitTests
                 long elapsed = sw.ElapsedMilliseconds;
                 Assert.True(elapsed >= 500, string.Format("Unexpected value (should be > 500): {0}", elapsed));
                 long variance = elapsed - 500;
+#if DEBUG
+                Assert.True(variance < 250, string.Format("Invalid timeout variance: {0}", variance));
+#else
                 Assert.True(variance < 100, string.Format("Invalid timeout variance: {0}", variance));
+#endif
 
                 // Test an invalid connection
                 server.Shutdown();

--- a/NATSUnitTests/UnitTestBasic.cs
+++ b/NATSUnitTests/UnitTestBasic.cs
@@ -68,6 +68,16 @@ namespace NATSUnitTests
         }
 
         [Fact]
+        public void TestBadOptionSubscriptionBatchSize()
+        {
+            Options opts = utils.DefaultTestOptions;
+
+            Assert.ThrowsAny<ArgumentException>(() => opts.SubscriptionBatchSize = -1);
+
+            Assert.ThrowsAny<ArgumentException>(() => opts.SubscriptionBatchSize = 0);
+        }
+
+        [Fact]
         public void TestSimplePublish()
         {
             using (new NATSServer())


### PR DESCRIPTION
This PR adds two improvements to `Channel<T>` usage within csnats:

1. Batched `get` operation.
2. PING/PONG use a specially designed channel for PONG relies (`SingleUseChannel<T>`).

A `tryAdd` member has been added to `Channel<T>` as well, to be used in a subsequent perf-related PR.

Using the supplied Benchmark utility, best-of-three runs were done comparing against master (read: not entirely scientific). My specs are the following: Processor=Intel(R) Xeon(R) CPU E5-2620 v3 2.40GHzIntel(R) Xeon(R) CPU E5-2620 v3 2.40GHz, ProcessorCount=24

The best of each results are given below:
```
                       | Baseline            | Channel<T>       | Delta           | Speedup  
----------- | -------- | ---------- | ------ | ------- | ------ | ------- | ----- | ----------- | ------------
            | Count    | msgs/s     | kb/s   | msgs/s  | kb/s   | msgs/s  | kb/s  | msgs/s      | kb/s        
PubOnlyNo   | 10000000 | 2302097    | 0      | 2549885 | 0      | 247788  | 0     | 1.107635777 |             
PubOnly8b   | 10000000 | 1982378    | 15487  | 2009341 | 15697  | 26963   | 210   | 1.013601341 | 1.01355976  
PubOnly32b  | 10000000 | 1664874    | 52027  | 1774239 | 55444  | 109365  | 3417  | 1.065689656 | 1.065677437 
PubOnly256b | 10000000 | 730606     | 182651 | 881915  | 220478 | 151309  | 37827 | 1.207100681 | 1.207099879 
PubOnly512b | 10000000 | 435323     | 217661 | 570142  | 285071 | 134819  | 67410 | 1.309698775 | 1.309701784 
PubOnly1k   | 1000000  | 233951     | 233951 | 304485  | 304485 | 70534   | 70534 | 1.301490483 | 1.301490483 
PubOnly4k   | 500000   | 57334      | 229336 | 79176   | 316704 | 21842   | 87368 | 1.380960687 | 1.380960687 
PubOnly8k   | 100000   | 28266      | 226128 | 37534   | 300272 | 9268    | 74144 | 1.327885092 | 1.327885092 
PubSubNo    | 10000000 | 603724     | 0      | 810147  | 0      | 206423  | 0     | 1.341916174 |             
PubSub8b    | 10000000 | 627404     | 4901   | 836156  | 6532   | 208752  | 1631  | 1.332723413 | 1.332789227 
PubSub32b   | 10000000 | 680405     | 21262  | 770157  | 24067  | 89752   | 2805  | 1.131909671 | 1.131925501 
PubSub256b  | 10000000 | 386603     | 96650  | 466495  | 116623 | 79892   | 19973 | 1.206651268 | 1.206652871 
PubSub512b  | 500000   | 235251     | 117625 | 270597  | 135298 | 35346   | 17673 | 1.150248033 | 1.150248672 
PubSub1k    | 500000   | 112693     | 112693 | 135642  | 135642 | 22949   | 22949 | 1.203641752 | 1.203641752 
PubSub4k    | 500000   | 28192      | 112768 | 35563   | 142252 | 7371    | 29484 | 1.261457151 | 1.261457151 
PubSub8k    | 100000   | 15635      | 125080 | 18280   | 146240 | 2645    | 21160 | 1.16917173  | 1.16917173  
ReqReplNo   | 20000    | 4447       | 0      | 6130    | 0      | 1683    | 0     | 1.378457387 |             
ReqRepl8b   | 10000    | 4080       | 31     | 5654    | 44     | 1574    | 13    | 1.385784314 | 1.419354839 
ReqRepl32b  | 10000    | 3905       | 122    | 5308    | 165    | 1403    | 43    | 1.359282971 | 1.352459016 
ReqRepl256b | 5000     | 3912       | 978    | 4750    | 1187   | 838     | 209   | 1.214212679 | 1.213701431 
ReqRepl512b | 5000     | 3396       | 1698   | 4438    | 2219   | 1042    | 521   | 1.306831567 | 1.306831567 
ReqRepl1k   | 5000     | 3767       | 3767   | 5817    | 5817   | 2050    | 2050  | 1.544199628 | 1.544199628 
ReqRepl4k   | 5000     | 2483       | 9932   | 4316    | 17264  | 1833    | 7332  | 1.738219895 | 1.738219895 
ReqRepl8k   | 5000     | 2106       | 16848  | 3362    | 26896  | 1256    | 10048 | 1.596391263 | 1.596391263
```
Basically an average of 1.29x improvement on my machine with a batch size of 64. This was empirically found to be the best batch size on my machine. That may depend heavily on the workload.
