### PR TITLE
Apply timeout option when connect to NATS server

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -388,15 +388,12 @@ namespace NATS.Client
                         sslStream = null;
                     }
 
-#if NET45
-                    client = new TcpClient(s.url.Host, s.url.Port);
-#else
                     client = new TcpClient();
                     if (!client.ConnectAsync(s.url.Host, s.url.Port).Wait(TimeSpan.FromMilliseconds(timeoutMillis)))
                     {
+                        client = null;
                         throw new NATSConnectionException("timeout");
                     }
-#endif
 
                     client.NoDelay = false;
 


### PR DESCRIPTION
This change is to be able to use timeout option when connect to NATS server. Timeout option is not applied in NET 4.5 version of NATS client  and default timeout (about 80 sec) is used.