### PR TITLE
prevent pingTimer from exhausting threads

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -877,6 +877,11 @@ namespace NATS.Client
                     sendPing(null);
                 }
                 catch (Exception) { }
+                //trigger timer again
+                if (ptmr != null)
+                {
+                    ptmr.Change(Opts.PingInterval, Timeout.Infinite);
+                }
             }
         }
 
@@ -901,7 +906,7 @@ namespace NATS.Client
             {
                 ptmr = new Timer(pingTimerCallback, null,
                     opts.PingInterval,
-                    opts.PingInterval);
+                    Timeout.Infinite); // do not trigger timer automatically : risk of having too many threads spawn during reconnect
             }
         }
 


### PR DESCRIPTION
Hello,

It's a long time without issues for us !

if doReconnect thread is slow or blocked (owning the mu lock), then the ping timer keeps creating threads waiting for the mu lock, until resources are exhausted.

We have a memory dump with > 900 threads for this timer. I'm still trying to find why the doReconnect thread was blocked while reading from the underlying socket