### PR TITLE
Always receive server connection notices

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -1058,7 +1058,6 @@ namespace NATS.Client
                         processConnectInit();
                         exToThrow = null;
 
-                        Console.WriteLine("Connected to: {0}", s.url);
                         return true;
                     }
                 }
@@ -1514,8 +1513,6 @@ namespace NATS.Client
                 }
                 catch (Exception) { }
 
-                Console.WriteLine("Successfully Reconnected to: {0}", cur.url);
-
                 return;
             }
 
@@ -1580,9 +1577,6 @@ namespace NATS.Client
                         throw new NATSException("Invalid Message length");
                         // continue;
                     }
-
-                    Console.WriteLine("=======================================");
-                    Console.WriteLine("IN ({0}): {1}", len, Encoding.Default.GetString(buffer, 0, len));
 
                     parser.parse(buffer, len);
                 }
@@ -2127,7 +2121,7 @@ namespace NATS.Client
         // processInfo is used to parse the info messages sent
         // from the server.
         // Caller must lock.
-        internal void processInfo(string json, bool notifyOnServerAddition, bool forced)
+        internal void processInfo(string json, bool notifyOnServerAddition, bool notifyOnServerReconnects)
         {
             if (json == null || IC._EMPTY_.Equals(json))
             {
@@ -2149,7 +2143,7 @@ namespace NATS.Client
                 }
 
                 var serverAdded = srvPool.Add(servers, true);
-                if (notifyOnServerAddition && (serverAdded || forced))
+                if (notifyOnServerAddition && (serverAdded || notifyOnServerReconnects))
                 {
                     scheduleConnEvent(opts.ServerDiscoveredEventHandler);
                 }

--- a/NATS.Client/Options.cs
+++ b/NATS.Client/Options.cs
@@ -22,6 +22,7 @@ namespace NATS.Client
         bool useOldRequestStyle = false;
         bool secure = false;
         bool allowReconnect = true;
+        bool alwaysReconnect = false;
         int maxReconnect  = Defaults.MaxReconnect;
         int reconnectWait = Defaults.ReconnectWait;
         int pingInterval  = Defaults.PingInterval;
@@ -327,6 +328,16 @@ namespace NATS.Client
         {
             get { return token; }
             set { token = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the flag to control whether we always reconnect
+        /// on a new server entering the mesh
+        /// </summary>
+        public bool AlwaysReconnect
+        {
+            get { return alwaysReconnect; }
+            set { alwaysReconnect = value; }
         }
 
         /// <summary>

--- a/NATS.Client/Options.cs
+++ b/NATS.Client/Options.cs
@@ -331,8 +331,9 @@ namespace NATS.Client
         }
 
         /// <summary>
-        /// Gets or sets the flag to control whether we always reconnect
-        /// on a new server entering the mesh
+        /// Gets or sets the flag to control whether to always allow
+        /// the ServerDiscoveredEventHandler to run if the notifyOnServerAddition
+        /// flag is set.
         /// </summary>
         public bool AlwaysReconnect
         {


### PR DESCRIPTION
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request: 

In conjunction with PR #597, here is the csharp client code changes that enable the INFO message to always pass through to the event handlers.  In this case, the event handler named 'ServerDiscoveredEventHandler' is allowed to trigger regardless if the client server list already has that server node in its list.  PR #597 allows the server to always send notification, and this change allows the client to always receive the change event notice.

Consequently, when combined with the server changes in PR#597, this allows user application code to be triggered every time there is a topology change to the clusters.  It will be up to the user application code to handle the event and maintain a list of server URLs to perform the desired (if any) reconnect.

### Who Benefits From The Change(s)?
Any configuration where the user application might want to be notified of a topology change regardless of cause (a reconnecting server, in this case) would benefit from this change.

