### PR TITLE
remove unnecessary lock during processMsg

### DIFF
--- a/NATS.Client/Subscription.cs
+++ b/NATS.Client/Subscription.cs
@@ -109,15 +109,11 @@ namespace NATS.Client
  
         internal bool tallyMessage(long bytes)
         {
-            lock (mu)
-            {
-                if (max > 0 && msgs > max)
-                    return true;
+            if (max > 0 && msgs > max)
+                return true;
 
-                this.msgs++;
-                this.bytes += bytes;
-
-            }
+            this.msgs++;
+            this.bytes += bytes;
 
             return false;
         }

--- a/NATS.Client/Subscription.cs
+++ b/NATS.Client/Subscription.cs
@@ -107,6 +107,7 @@ namespace NATS.Client
             }
         }
  
+        //caller must lock
         internal bool tallyMessage(long bytes)
         {
             if (max > 0 && msgs > max)


### PR DESCRIPTION
Lock during conn.processMsg is unnecessary. It's single thread processing, already thread safe.