### PR TITLE
Ensure that the connection is disposed of if an exception happens while connecting

### DIFF
--- a/NATS.Client/ConnectionFactory.cs
+++ b/NATS.Client/ConnectionFactory.cs
@@ -95,7 +95,15 @@ namespace NATS.Client
         public IConnection CreateConnection(Options opts)
         {
             Connection nc = new Connection(opts);
-            nc.connect();
+            try
+            {
+                nc.connect();
+            }
+            catch (System.Exception)
+            {
+                nc.Dispose();
+                throw;
+            }
             return nc;
         }
 
@@ -149,7 +157,15 @@ namespace NATS.Client
         public IEncodedConnection CreateEncodedConnection(Options opts)
         {
             EncodedConnection nc = new EncodedConnection(opts);
-            nc.connect();
+            try
+            {
+                nc.connect();
+            }
+            catch (System.Exception)
+            {
+                nc.Dispose();
+                throw;
+            }
             return nc;
         }
     }


### PR DESCRIPTION
I had an application which could end up with hundreds of NATS threads if no server was available. The application would call CreateConnection repeatedly to try to establish a connection.