### PR TITLE
 reset stream position after processing '\n'

### DIFF
--- a/NATS.Client/Parser.cs
+++ b/NATS.Client/Parser.cs
@@ -498,6 +498,7 @@ namespace NATS.Client
                                 break;
                             case '\n':
                                 conn.processAsyncInfo(argBufBase, (int)argBufStream.Position);
+								argBufStream.Position = 0;
                                 state = OP_START;
                                 break;
                             default:


### PR DESCRIPTION
This bug caused a reconnect when a new server was discovered while performing requests. How to reproduce:

1) Start nats server A with cluster param
2) Start client with server A
3) client does request and handles the requests himself (every 5 seconds)
4) Start nats server B with cluster and routes param pointing to server A
5) Client will raise discover event and then disconnected and reconnected

Logs:
[15:26:03 VRB] Connecting NATS with following options: {AllowReconnect=True;MaxPingsOut=2;MaxReconnect=60;RequestTimeout=5000;Name=NATSTestClient;NoRandomize=False;Pendantic=False;UseOldRequestStyle=False;PingInterval=120000;ReconnectWait=2000;Secure=False;User=;Token=;SubscriberDeliveryTaskCount=0;SubscriptionBatchSize=64;Servers={[10.10.10.70:4222]}SubChannelLength=65536;Timeout=2000;Pendantic=False}
[15:26:03 INF] NATS connected connectionId: R9EQlaFEjuxCWgeM65EhlT connectionURL: 'nats://10.10.10.70:4222' servers: 'nats://10.10.10.70:4222' discovered servers: ''
[15:26:03 VRB] NATS started
[15:26:03 VRB] Starting up services
[15:26:03 VRB] Starting service NATSTestClient
[15:26:03 VRB] Starting
[15:26:03 VRB] Services started
[15:26:03 INF] running
[15:26:08 DBG] send request {"Subject":"cyo.test.req","RequestId":461498656,"ElevateLog":false,"Message":{"Request":"hello_0"}}
[15:26:08 VRB] NATS handle request for subject: cyo.test.req req_id: 461498656 type: 1 connection id: R9EQlaFEjuxCWgeM65EhlT connection url: nats://10.10.10.70:4222
[15:26:08 DBG] received request {"Subject":"cyo.test.req","RequestId":461498656,"ElevateLog":false,"Message":{"Request":"hello_0"}}
[15:26:08 DBG] send reply {"Subject":"cyo.test.req","RequestId":461498656,"ElevateLog":false,"Message":{"Reply":"hello_0"}}
[15:26:08 DBG] received reply {"Subject":"cyo.test.req","RequestId":461498656,"ElevateLog":false,"Message":{"Reply":"hello_0"}}
[15:26:13 DBG] send request {"Subject":"cyo.test.req","RequestId":461498657,"ElevateLog":false,"Message":{"Request":"hello_1"}}
[15:26:13 VRB] NATS handle request for subject: cyo.test.req req_id: 461498657 type: 1 connection id: R9EQlaFEjuxCWgeM65EhlT connection url: nats://10.10.10.70:4222
[15:26:13 DBG] received request {"Subject":"cyo.test.req","RequestId":461498657,"ElevateLog":false,"Message":{"Request":"hello_1"}}
[15:26:13 DBG] send reply {"Subject":"cyo.test.req","RequestId":461498657,"ElevateLog":false,"Message":{"Reply":"hello_1"}}
[15:26:13 DBG] received reply {"Subject":"cyo.test.req","RequestId":461498657,"ElevateLog":false,"Message":{"Reply":"hello_1"}}
[15:26:17 INF] NATS server discovered connectionId: R9EQlaFEjuxCWgeM65EhlT connectionURL: 'nats://10.10.10.70:4222' servers: 'nats://10.10.10.70:4222,nats://10.10.10.70:4223,nats://10.0.75.1:4223,nats://192.168.244.113:4223,nats://172.26.16.1:4223' discovered servers: 'nats://10.10.10.70:4223,nats://10.0.75.1:4223,nats://192.168.244.113:4223,nats://172.26.16.1:4223' last error: ''
[15:26:18 DBG] send request {"Subject":"cyo.test.req","RequestId":461498658,"ElevateLog":false,"Message":{"Request":"hello_2"}}
[15:26:18 WRN] NATS connection disconnected connectionId:  connectionURL: 'null' servers: 'nats://10.10.10.70:4223,nats://10.0.75.1:4223,nats://192.168.244.113:4223,nats://172.26.16.1:4223,nats://10.10.10.70:4222' discovered servers: 'nats://10.10.10.70:4223,nats://10.0.75.1:4223,nats://192.168.244.113:4223,nats://172.26.16.1:4223' last error:
[15:26:19 INF] Nats connection reconnected connectionId: KjTM7pA6WWxNa4qkTTMC7U connectionURL: 'nats://10.10.10.70:4223' servers: 'nats://10.10.10.70:4223,nats://10.0.75.1:4223,nats://192.168.244.113:4223,nats://172.26.16.1:4223,nats://10.10.10.70:4222,nats://10.0.75.1:4222,nats://172.26.16.1:4222,nats://192.168.244.113:4222' discovered servers: 'nats://10.10.10.70:4223,nats://10.0.75.1:4223,nats://192.168.244.113:4223,nats://172.26.16.1:4223,nats://10.0.75.1:4222,nats://172.26.16.1:4222,nats://192.168.244.113:4222' last error: ''
[15:26:23 DBG] send request {"Subject":"cyo.test.req","RequestId":461498659,"ElevateLog":false,"Message":{"Request":"hello_3"}}
[15:26:23 VRB] NATS handle request for subject: cyo.test.req req_id: 461498659 type: 1 connection id: KjTM7pA6WWxNa4qkTTMC7U connection url: nats://10.10.10.70:4223
[15:26:23 DBG] received request {"Subject":"cyo.test.req","RequestId":461498659,"ElevateLog":false,"Message":{"Request":"hello_3"}}
[15:26:23 DBG] send reply {"Subject":"cyo.test.req","RequestId":461498659,"ElevateLog":false,"Message":{"Reply":"hello_3"}}
[15:26:23 DBG] received reply {"Subject":"cyo.test.req","RequestId":461498659,"ElevateLog":false,"Message":{"Reply":"hello_3"}}
[15:26:23 FTL] NATS request failed subject: cyo.test.req req_id: 461498658 type: 1 connection id: KjTM7pA6WWxNa4qkTTMC7U connection url: nats://10.10.10.70:4223, exception: System.AggregateException: One or more errors occurred. (Timeout occurred.) ---> NATS.Client.NATSTimeoutException: Timeout occurred.
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at NATS.Client.Connection.<>c__DisplayClass131_0.<<requestAsync>b__0>d.MoveNext()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Colyoo.Messaging.NATS.Client.HandleRequestResult(Task`1 result, TaskCompletionSource`1 taskSource, MessageStream msgStream, String subject) in C:\development\colyoo_csharp_server_base\ServiceBase\NATSClient\PubSubClient.cs:line 169
---> (Inner Exception #0) NATS.Client.NATSTimeoutException: Timeout occurred.
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at NATS.Client.Connection.<>c__DisplayClass131_0.<<requestAsync>b__0>d.MoveNext()<---

[15:26:28 DBG] send request {"Subject":"cyo.test.req","RequestId":461498660,"ElevateLog":false,"Message":{"Request":"hello_4"}}
[15:26:28 VRB] NATS handle request for subject: cyo.test.req req_id: 461498660 type: 1 connection id: KjTM7pA6WWxNa4qkTTMC7U connection url: nats://10.10.10.70:4223
[15:26:28 DBG] received request {"Subject":"cyo.test.req","RequestId":461498660,"ElevateLog":false,"Message":{"Request":"hello_4"}}
[15:26:28 DBG] send reply {"Subject":"cyo.test.req","RequestId":461498660,"ElevateLog":false,"Message":{"Reply":"hello_4"}}
[15:26:28 DBG] received reply {"Subject":"cyo.test.req","RequestId":461498660,"ElevateLog":false,"Message":{"Reply":"hello_4"}}