### PR TITLE
Fix for #210 - race condition in case of concurrent requests

### DIFF
--- a/NATS.Client/AsyncSub.cs
+++ b/NATS.Client/AsyncSub.cs
@@ -35,7 +35,6 @@ namespace NATS.Client
         /// </summary>
         public event EventHandler<MsgHandlerEventArgs> MessageHandler;
 
-        private MsgHandlerEventArgs msgHandlerArgs = new MsgHandlerEventArgs();
         private Task                msgFeeder = null;
 
         private bool started = false;
@@ -82,10 +81,15 @@ namespace NATS.Client
 
             if (localMax <= 0 || d <= localMax)
             {
-                msgHandlerArgs.msg = msg;
                 try
                 {
-                    localHandler(this, msgHandlerArgs);
+                    if (localHandler != null)
+                    {
+                        var msgHandlerEventArgs = new MsgHandlerEventArgs();
+                        msgHandlerEventArgs.msg = msg;
+
+                        localHandler(this, msgHandlerEventArgs);
+                    }
                 }
                 catch (Exception) { }
 


### PR DESCRIPTION
This change fixes issue #210. Root cause: state variable msgHandlerArgs which is updated concurrently. Now new instance of MsgHandlerEventArgs is allocated for each Msg.