### PR TITLE
.NET standard 1.6

### DIFF
--- a/NATS.Client/NATS.Client.csproj
+++ b/NATS.Client/NATS.Client.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright The NATS Authors 2017-2018</Copyright>
     <AssemblyTitle>NATS Client</AssemblyTitle>
     <VersionPrefix>0.8.1</VersionPrefix>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>NATS.Client</AssemblyName>
     <PackageId>NATS.Client</PackageId>


### PR DESCRIPTION
Revert back to .NET standard 1.6 for the NATS client library.