### PR TITLE
Ensure request/reply APIs only throw a NATSTimeoutException on timeout

### DIFF
--- a/NATSUnitTests/UnitTestBasic.cs
+++ b/NATSUnitTests/UnitTestBasic.cs
@@ -526,8 +526,17 @@ namespace NATSUnitTests
             {
                 using (IConnection c = utils.DefaultTestConnection)
                 {
-                    Assert.ThrowsAny<Exception>(() => c.Request("foo", null, 500));
+                    Assert.Throws<NATSTimeoutException>(() => c.Request("foo", null, 50));  
                 }
+
+                Options opts = utils.DefaultTestOptions;
+                opts.UseOldRequestStyle = true;
+
+                using (IConnection c = new ConnectionFactory().CreateConnection(opts))
+                {
+                    Assert.Throws<NATSTimeoutException>(() => c.Request("foo", null, 50));
+                }
+
             }
         }
 


### PR DESCRIPTION
The request API was improperly throwing an aggregate exception.
* Extract and throw the inner exception from an AggregateException.
* Fix tests to property check for this.

Signed-off-by: Colin Sullivan <colin@synadia.com>