### PR TITLE
Add the ability to infinitely reconnect

### DIFF
--- a/NATS.Client/Options.cs
+++ b/NATS.Client/Options.cs
@@ -241,9 +241,17 @@ namespace NATS.Client
             set { allowReconnect = value; }
         }
 
+
+        /// <summary>
+        /// Set <see cref="Options.MaxReconnect"/> to this value for the client to attempt to
+        /// connect indefinitely. 
+        /// </summary>
+        public static int ReconnectForever = -1;
+
         /// <summary>
         /// Gets or sets the maxmimum number of times a connection will
-        /// attempt to reconnect.
+        /// attempt to reconnect.  To reconnect indefinitely set this value to
+        /// <see cref="Options.ReconnectForever"/>
         /// </summary>
         public int MaxReconnect
         {

--- a/NATS.Client/ServerPool.cs
+++ b/NATS.Client/ServerPool.cs
@@ -156,19 +156,15 @@ namespace NATS.Client
                 // remove the current server.
                 sList.Remove(s);
 
-                if (maxReconnect > 0 && s.reconnects < maxReconnect)
+                if (maxReconnect == Options.ReconnectForever || 
+                   (maxReconnect > 0 && s.reconnects < maxReconnect))
                 {
                     // if we haven't surpassed max reconnects, add it
                     // to try again.
                     sList.AddLast(s);
                 }
 
-                if (isEmpty())
-                {
-                    return null;
-                }
-
-                currentServer = sList.First();
+                currentServer = isEmpty() ? null : sList.First();
 
                 return currentServer;
             }


### PR DESCRIPTION
This PR adds a new `Options.ReconnectForever` value that can be set on `Options.MaxReconnects` to specify that a connection will infinitely attempt to reconnect.

Signed-off-by: Colin Sullivan <colin@synadia.com>