### PR TITLE
Update INFO processing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 install:
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-  - appveyor DownloadFile https://github.com/nats-io/gnatsd/releases/download/v0.9.6/gnatsd-v0.9.6-windows-386.zip
-  - 7z e gnatsd-v0.9.6-windows-386.zip gnatsd.exe -r -oc:\projects\csharp-nats\build
+  - appveyor DownloadFile https://github.com/nats-io/gnatsd/releases/download/v1.1.0/gnatsd-v1.1.0-windows-amd64.zip
+  - 7z e gnatsd-v1.1.0-windows-amd64.zip gnatsd.exe -r -oc:\projects\csharp-nats\build
   - cmd: set PATH=%PATH%;C:\projects\csharp-nats\build
 
 # to add several configurations to build matrix:


### PR DESCRIPTION
Update server INFO processing to prune out old/unreferenced implicit servers.

* Remove randomization of discovered server list (no longer necessary)
* Prune out implicit servers if not referenced by the INFO update
* Thoroughly test, including testing integrity of the server and discovered server list.
* Update the NATS server version for testing

Mirrors https://github.com/nats-io/go-nats/pull/344