### PR TITLE
Stop reading from TCP socket when host has gracefully disconnected.

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -1577,6 +1577,13 @@ namespace NATS.Client
                 try
                 {
                     len = br.Read(buffer, 0, Defaults.defaultReadLength);
+
+                    // Socket has been closed gracefully by host
+                    if (len == 0)
+                    {
+                        break;
+                    }
+
                     parser.parse(buffer, len);
                 }
                 catch (Exception e)


### PR DESCRIPTION
Was experiencing high CPU usage in a .NET 4.5 nats-streaming-client application when I shutdown the nats-streaming-server gracefully (Ctrl + C). After some debugging it seemed to be this read method, which makes sense as a length of 0 is returned by the read method if the TPC socked has been shutdown by the host gracefully.

Have done a quick debug build + run and this change seems to fix the issue. I've not tested the unit tests (need to spin up multiple NATS servers?) or the .NET Core version.