### PR TITLE
Fix a memory leak in request/reply

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -148,7 +148,7 @@ namespace NATS.Client
             new Dictionary<string, InFlightRequest>(StringComparer.OrdinalIgnoreCase);
 
         // Handles in-flight requests when using the new-style request/reply behavior
-        private sealed class InFlightRequest
+        private sealed class InFlightRequest : IDisposable
         {
             public InFlightRequest(CancellationToken token, int timeout)
             {
@@ -165,7 +165,7 @@ namespace NATS.Client
                             timeoutToken.Token, token);
                         this.Token = linkedTokenSource.Token;
 
-                        timeoutToken.Token.Register(
+                        this.TimeoutTokenRegistration = timeoutToken.Token.Register(
                             () => this.Waiter.TrySetException(new NATSTimeoutException()));
                         timeoutToken.CancelAfter(timeout);
                     }
@@ -180,8 +180,7 @@ namespace NATS.Client
                     {
                         var timeoutToken = new CancellationTokenSource();
                         this.Token = timeoutToken.Token;
-
-                        timeoutToken.Token.Register(
+                        this.TimeoutTokenRegistration = timeoutToken.Token.Register(
                             () => this.Waiter.TrySetException(new NATSTimeoutException()));
                         timeoutToken.CancelAfter(timeout);
                     }
@@ -190,7 +189,13 @@ namespace NATS.Client
 
             public string Id { get; set; }
             public CancellationToken Token { get; private set; }
+            public CancellationTokenRegistration TimeoutTokenRegistration { get; private set; }
             public TaskCompletionSource<Msg> Waiter { get; private set; }
+
+            public void Dispose()
+            {
+                this.TimeoutTokenRegistration.Dispose();
+            }
         }
 
         // Prepare protocol messages for efficiency
@@ -2492,8 +2497,6 @@ namespace NATS.Client
 
                 request.Id = (nextRequestId++).ToString(CultureInfo.InvariantCulture);
 
-                request.Token.Register(() => removeOutstandingRequest(request.Id));
-
                 waitingRequests.Add(
                     request.Id,
                     request);
@@ -2612,6 +2615,7 @@ namespace NATS.Client
             {
                 request.Waiter.SetCanceled();
             }
+            request.Dispose();
         }
 
         private void removeOutstandingRequest(string requestId)


### PR DESCRIPTION
Various resources associated with the timer were being leaked.   This fix tracks and disposes of the resources by disposing the token cancellation registration for the timeout cancellation token, and the primary token for the in-flight request. 

Resolves #227 

Signed-off-by: Colin Sullivan <colin@synadia.com>