### PR TITLE
allowing publishers to not be affected by the presence of slow consumers

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -1320,8 +1320,6 @@ namespace NATS.Client
         private void processDisconnect()
         {
             status = ConnState.DISCONNECTED;
-            if (lastEx == null)
-                return;
         }
 
         // This will process a disconnect when reconnect is allowed.
@@ -1955,7 +1953,6 @@ namespace NATS.Client
             return value;
         }
 
-
         // processMsg is called by parse and will place the msg on the
         // appropriate channel for processing. All subscribers have their
         // their own channel. If the channel is full, the connection is
@@ -2003,7 +2000,6 @@ namespace NATS.Client
         // async error handler if registered.
         internal void processSlowConsumer(Subscription s)
         {
-            lastEx = new NATSSlowConsumerException();
             if (opts.AsyncErrorEventHandler != null && !s.sc)
             {
                 EventHandler<ErrEventArgs> aseh = opts.AsyncErrorEventHandler;


### PR DESCRIPTION
While using NATS Streaming I came across a weird issue. I was getting from time to time a NATSSlowConsumerException when trying to acknowledge a message. I would like to state that we are using manual acknowledgement, meaning that processing a single message could take "some time". What was weird is that I thought that by using streaming I should be shielded from this type of errors, then I decided to take a look at the code of the underlying NATS client. 

What I found was that if any subscription is being categorized as slow, the following method is called: NATS.Client.Connection.processSlowConsumer(Subscription s). And this is what that method was doing in its first line:

- lastEx = new NATSSlowConsumerException();

The problem whit that is that if the same NATS client is used in an application for publishing and subscribing, the fact that some subscription is marked as slow prevents any message from being published since the following lines are found in the internal publish method of the connection class:

if (lastEx != null)
    throw lastEx;

The problem we were having was caused by the fact that acknowledging a message means publishing a message using the internal publish method.