### PR TITLE
Default the count of published messages to 1

### DIFF
--- a/examples/Publish/publish.cs
+++ b/examples/Publish/publish.cs
@@ -25,7 +25,7 @@ namespace NATSExamples
     {
         Dictionary<string, string> parsedArgs = new Dictionary<string, string>();
 
-        int count = 2000000;
+        int count = 1;
         string url = Defaults.Url;
         string subject = "foo";
         byte[] payload = null;


### PR DESCRIPTION
It seems that 1 would be a better default count for the publish example.