### PR TITLE
Fix memory leak on timed out connection attempt

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -439,6 +439,7 @@ namespace NATS.Client
                     task.ContinueWith(t => GC.KeepAlive(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
                     if (!task.Wait(TimeSpan.FromMilliseconds(timeoutMillis)))
                     {
+                        close(client);
                         client = null;
                         throw new NATSConnectionException("timeout");
                     }
@@ -467,7 +468,7 @@ namespace NATS.Client
                 return false;
             }
 
-            internal void closeClient(TcpClient c)
+            internal static void close(TcpClient c)
             {
                 if (c != null)
                 {
@@ -500,7 +501,7 @@ namespace NATS.Client
                 }
                 catch (Exception ex)
                 {
-                    closeClient(client);
+                    close(client);
                     throw new NATSConnectionException("TLS Authentication error", ex);
                 }
             }
@@ -540,7 +541,7 @@ namespace NATS.Client
                         s.Dispose();
 
                     if (c != null)
-                        closeClient(c);
+                        close(c);
                 }
                 catch (Exception) { }
             }
@@ -601,7 +602,7 @@ namespace NATS.Client
                     if (stream != null)
                         stream.Dispose();
                     if (client != null)
-                        closeClient(client);
+                        close(client);
 
                     disposedValue = true;
                 }

--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -501,6 +501,7 @@ namespace NATS.Client
                 }
                 catch (Exception ex)
                 {
+                    sslStream.Dispose();
                     close(client);
                     throw new NATSConnectionException("TLS Authentication error", ex);
                 }

--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -502,6 +502,8 @@ namespace NATS.Client
                 catch (Exception ex)
                 {
                     sslStream.Dispose();
+                    sslStream = null;
+
                     close(client);
                     throw new NATSConnectionException("TLS Authentication error", ex);
                 }


### PR DESCRIPTION
Fix a memory leak upon a failed connection.

Note, upon a first failed connection there will be a bump in memory of a few Kb as the .NET runtime allocates objects required to create a socket.  This is a one time allocation.  With this fix, memory remains stable after that point.

In debugging this, some tasks associated with the TCP client connection were collected while others were not, so there was not a one-to-one leaked object per failed attempt.  No leaked objects had references to, or were referenced by NATS.Client objects - at least that the memory profiler would report.  I did not get to the bottom of that mystery, but quantitatively testing a loop of 1000 failed connection attempts measuring memory + object counts indicated this bug was fixed with the changes.

Resolves #236.

Signed-off-by: Colin Sullivan <colin@synadia.com>