### PR TITLE
Check for subject and queue name validity

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -3238,9 +3238,13 @@ namespace NATS.Client
         internal AsyncSubscription subscribeAsync(string subject, string queue,
             EventHandler<MsgHandlerEventArgs> handler)
         {
-            if (string.IsNullOrWhiteSpace(subject))
+            if (!Subscription.IsValidSubject(subject))
             {
-                throw new NATSBadSubscriptionException();
+                throw new NATSBadSubscriptionException("Invalid subject.");
+            }
+            if (queue != null && !Subscription.IsValidQueueGroupName(queue))
+            {
+                throw new NATSBadSubscriptionException("Invalid queue group name.");
             }
 
             AsyncSubscription s = null;
@@ -3272,9 +3276,13 @@ namespace NATS.Client
         // function that indicates interest in a subject.
         private SyncSubscription subscribeSync(string subject, string queue)
         {
-            if (string.IsNullOrWhiteSpace(subject))
+            if (!Subscription.IsValidSubject(subject))
             {
-                throw new NATSBadSubscriptionException();
+                throw new NATSBadSubscriptionException("Invalid subject.");
+            }
+            if (queue != null && !Subscription.IsValidQueueGroupName(queue))
+            {
+                throw new NATSBadSubscriptionException("Invalid queue group name.");
             }
 
             SyncSubscription s = null;

--- a/NATS.Client/Exceptions.cs
+++ b/NATS.Client/Exceptions.cs
@@ -122,7 +122,8 @@ namespace NATS.Client
     /// </summary>
     public class NATSBadSubscriptionException : NATSException
     {
-        internal NATSBadSubscriptionException() : base("Subcription is not valid.") { }
+        internal NATSBadSubscriptionException() : base("Subscription is not valid.") { }
+        internal NATSBadSubscriptionException(string s) : base("s") { }
     }
 
     /// <summary>

--- a/NATS.Client/Subscription.cs
+++ b/NATS.Client/Subscription.cs
@@ -648,6 +648,50 @@ namespace NATS.Client
             }
         }
 
+        #region validation
+
+        static private readonly char[] invalidSubjectChars = { '\r', '\n', '\t', ' '};
+
+        private static bool IsValidTokenOrQName(string value)
+        {
+            return (!string.IsNullOrEmpty(value) && value.LastIndexOfAny(invalidSubjectChars) < 0);
+        }
+
+        /// <summary>
+        /// Checks if a subject is valid.
+        /// </summary>
+        /// <param name="subject">The subject to check</param>
+        /// <returns>true if valid, false otherwise.</returns>
+        static public bool IsValidSubject(string subject)
+        {
+            if (!IsValidTokenOrQName(subject))
+            {
+                return false;
+            }
+
+            string[] tokens = subject.Split('.');
+            foreach (string t in tokens)
+            {
+                if (t.Length == 0)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if the queue group name is valid.
+        /// </summary>
+        /// <param name="queueGroup"></param>
+        /// <returns>true is the queue group name is valid, false otherwise.</returns>
+        static public bool IsValidQueueGroupName(string queueGroup)
+        {
+            return IsValidTokenOrQName(queueGroup);
+        }
+
+        #endregion
+
     }  // Subscription
 
 }

--- a/NATS.Client/Subscription.cs
+++ b/NATS.Client/Subscription.cs
@@ -652,9 +652,9 @@ namespace NATS.Client
 
         static private readonly char[] invalidSubjectChars = { '\r', '\n', '\t', ' '};
 
-        private static bool IsValidTokenOrQName(string value)
+        private static bool ContainsInvalidChars(string value)
         {
-            return (!string.IsNullOrEmpty(value) && value.LastIndexOfAny(invalidSubjectChars) < 0);
+            return string.IsNullOrEmpty(value) || value.IndexOfAny(invalidSubjectChars) >= 0;
         }
 
         /// <summary>
@@ -662,20 +662,17 @@ namespace NATS.Client
         /// </summary>
         /// <param name="subject">The subject to check</param>
         /// <returns>true if valid, false otherwise.</returns>
-        static public bool IsValidSubject(string subject)
+        public static bool IsValidSubject(string subject)
         {
-            if (!IsValidTokenOrQName(subject))
+            if (ContainsInvalidChars(subject))
             {
                 return false;
             }
 
-            string[] tokens = subject.Split('.');
-            foreach (string t in tokens)
+            // Avoid split for performance, in case this is ever called in the fastpath.
+            if (subject.StartsWith(".") || subject.EndsWith(".") || subject.Contains(".."))
             {
-                if (t.Length == 0)
-                {
-                    return false;
-                }
+                return false;
             }
             return true;
         }
@@ -685,9 +682,9 @@ namespace NATS.Client
         /// </summary>
         /// <param name="queueGroup"></param>
         /// <returns>true is the queue group name is valid, false otherwise.</returns>
-        static public bool IsValidQueueGroupName(string queueGroup)
+        public static bool IsValidQueueGroupName(string queueGroup)
         {
-            return IsValidTokenOrQName(queueGroup);
+            return ContainsInvalidChars(queueGroup) == false;
         }
 
         #endregion


### PR DESCRIPTION
Check for subject and queue name validity.

See:
- https://github.com/nats-io/nats-server/issues/84
- https://github.com/nats-io/nats.go/issues/498
- https://github.com/nats-io/nats.go/pull/500

Resolves #280 

Signed-off-by: Colin Sullivan <colin@synadia.com>