### PR TITLE
Add Message.Respond implementing #281

### DIFF
--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -3439,8 +3439,9 @@ namespace NATS.Client
                 if (isClosed())
                     throw new NATSConnectionClosedException();
 
-                Subscription s = subs[sub.sid];
-                if (s == null)
+                Subscription s;
+                if (!subs.TryGetValue(sub.sid, out s)
+                    || s == null)
                 {
                     // already unsubscribed
                     return null;

--- a/NATS.Client/Conn.cs
+++ b/NATS.Client/Conn.cs
@@ -3485,7 +3485,6 @@ namespace NATS.Client
                 s.mch = null;
             }
 
-            s.conn = null;
             s.closed = true;
         }
 

--- a/NATS.Client/Msg.cs
+++ b/NATS.Client/Msg.cs
@@ -168,6 +168,31 @@ namespace NATS.Client
         }
 
         /// <summary>
+        /// Send a response to the message on the arrival subscription.
+        /// </summary>
+        /// <param name="data">The response payload to send.</param>
+        /// <exception cref="NATSException">
+        /// <para><see cref="Reply"/> is null or empty.</para>
+        /// <para>-or-</para>
+        /// <para><see cref="ArrivalSubcription"/> is null.</para>
+        /// </exception>
+        public void Respond(byte[] data)
+        {
+            if (String.IsNullOrEmpty(Reply))
+            {
+                throw new NATSException("No Reply subject");
+            }
+
+            Connection conn = ArrivalSubcription?.Connection;
+            if (conn == null)
+            {
+                throw new NATSException("Message is not bound to a subscription");
+            }
+
+            conn.Publish(this.Reply, data);
+        }
+
+        /// <summary>
         /// Generates a string representation of the messages.
         /// </summary>
         /// <returns>A string representation of the messages.</returns>

--- a/NATS.Client/Subscription.cs
+++ b/NATS.Client/Subscription.cs
@@ -237,12 +237,24 @@ namespace NATS.Client
                 isClosed = this.closed;
             }
 
-            if (c == null || closed)
+            if (c == null)
             {
                 if (throwEx)
                     throw new NATSBadSubscriptionException();
 
                 return;
+            }
+
+            if (c.IsClosed())
+            {
+                if (throwEx)
+                    throw new NATSConnectionClosedException();
+            }
+
+            if (isClosed)
+            {
+                if (throwEx)
+                    throw new NATSBadSubscriptionException();
             }
 
             if (c.IsDraining())
@@ -283,7 +295,13 @@ namespace NATS.Client
 
             lock (mu)
             {
-                if (conn == null || closed)
+                if (conn == null)
+                    throw new NATSBadSubscriptionException();
+
+                if (conn.IsClosed())
+                    throw new NATSConnectionClosedException();
+
+                if (closed)
                     throw new NATSBadSubscriptionException();
 
                 c = conn;

--- a/NATSUnitTests/UnitTestSub.cs
+++ b/NATSUnitTests/UnitTestSub.cs
@@ -1046,28 +1046,28 @@ namespace NATSUnitTests
             using (new NATSServer())
             {
                 using (IConnection c = utils.DefaultTestConnection)
+                using (ISyncSubscription s = c.SubscribeSync("foo"))
                 {
-                    ISyncSubscription s = c.SubscribeSync("foo");
-
                     string replyTo = c.NewInbox();
-                    ISyncSubscription r = c.SubscribeSync(replyTo);
+                    using (ISyncSubscription r = c.SubscribeSync(replyTo))
+                    {
+                        c.Publish("foo", replyTo, Encoding.UTF8.GetBytes("message"));
 
-                    c.Publish("foo", replyTo, Encoding.UTF8.GetBytes("message"));
+                        Msg m = s.NextMessage(1000);
+                        Assert.NotNull(m);
+                        Assert.Equal(replyTo, m.Reply);
 
-                    Msg m = s.NextMessage(1000);
-                    Assert.NotNull(m);
-                    Assert.Equal(replyTo, m.Reply);
+                        byte[] reply = Encoding.UTF8.GetBytes("reply");
+                        m.Respond(reply);
 
-                    byte[] reply = Encoding.UTF8.GetBytes("reply");
-                    m.Respond(reply);
+                        m = r.NextMessage(1000);
+                        Assert.NotNull(m);
+                        Assert.Equal(replyTo, m.Subject);
+                        Assert.Equal(reply, m.Data);
 
-                    m = r.NextMessage(1000);
-                    Assert.NotNull(m);
-                    Assert.Equal(replyTo, m.Subject);
-                    Assert.Equal(reply, m.Data);
-
-                    s.Unsubscribe();
-                    r.Unsubscribe();
+                        s.Unsubscribe();
+                        r.Unsubscribe();
+                    }
                 }
             }
         }
@@ -1078,29 +1078,96 @@ namespace NATSUnitTests
             using (new NATSServer())
             {
                 using (IConnection c = utils.DefaultTestConnection)
+                using (ISyncSubscription s = c.SubscribeSync("foo"))
                 {
-                    ISyncSubscription s = c.SubscribeSync("foo");
                     s.AutoUnsubscribe(1);
 
                     string replyTo = c.NewInbox();
-                    ISyncSubscription r = c.SubscribeSync(replyTo);
+                    using (ISyncSubscription r = c.SubscribeSync(replyTo))
+                    {
+                        c.Publish("foo", replyTo, Encoding.UTF8.GetBytes("message"));
 
+                        Msg m = s.NextMessage(1000);
+                        Assert.NotNull(m);
+                        Assert.Equal(replyTo, m.Reply);
+
+                        byte[] reply = Encoding.UTF8.GetBytes("reply");
+                        m.Respond(reply);
+
+                        m = r.NextMessage(1000);
+                        Assert.NotNull(m);
+                        Assert.Equal(replyTo, m.Subject);
+                        Assert.Equal(reply, m.Data);
+
+                        r.Unsubscribe();
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void TestRespondFailsWithClosedConnection()
+        {
+            using (new NATSServer())
+            {
+                using (IConnection c = utils.DefaultTestConnection)
+                {
+                    ISyncSubscription s = c.SubscribeSync("foo");
+
+                    string replyTo = c.NewInbox();
                     c.Publish("foo", replyTo, Encoding.UTF8.GetBytes("message"));
 
                     Msg m = s.NextMessage(1000);
                     Assert.NotNull(m);
                     Assert.Equal(replyTo, m.Reply);
 
+                    c.Close();
+
                     byte[] reply = Encoding.UTF8.GetBytes("reply");
-                    m.Respond(reply);
+                    Assert.ThrowsAny<NATSConnectionClosedException>(() => m.Respond(reply));
 
-                    m = r.NextMessage(1000);
-                    Assert.NotNull(m);
-                    Assert.Equal(replyTo, m.Subject);
-                    Assert.Equal(reply, m.Data);
-
-                    r.Unsubscribe();
+                    s.Dispose();
                 }
+            }
+        }
+
+        [Fact]
+        public void TestRespondFailsWithServerClosed()
+        {
+            IConnection c = null;
+            ISyncSubscription s = null;
+            try
+            {
+                Msg m;
+                using (NATSServer ns = new NATSServer())
+                {
+                    Options options = utils.DefaultTestOptions;
+                    options.AllowReconnect = false;
+
+                    c = new ConnectionFactory().CreateConnection(options);
+                    s = c.SubscribeSync("foo");
+
+                    string replyTo = c.NewInbox();
+
+                    c.Publish("foo", replyTo, Encoding.UTF8.GetBytes("message"));
+
+                    m = s.NextMessage(1000);
+                    Assert.NotNull(m);
+                    Assert.Equal(replyTo, m.Reply);
+
+                    ns.Shutdown();
+                }
+
+                // Give the server time to close
+                Thread.Sleep(2000);
+
+                byte[] reply = Encoding.UTF8.GetBytes("reply");
+                Assert.ThrowsAny<NATSConnectionClosedException>(() => m.Respond(reply));
+            }
+            finally
+            {
+                c?.Dispose();
+                s?.Dispose();
             }
         }
     }


### PR DESCRIPTION
Implements #281 by adding Respond to Msg to simplify responses to Request-Reply.

I brought over the same changes to Subscription that landed in https://github.com/nats-io/nats.go/pull/489/files however this breaks TestConnection.TestClosedConnections which had certain assumptions about the exception messages.

Should we alter the unit test to keep parity with the go client, or should we alter the code to keep raising the same exception?