### PR TITLE
Add Reconnect Buffering

### DIFF
--- a/NATS.Client/Exceptions.cs
+++ b/NATS.Client/Exceptions.cs
@@ -36,6 +36,15 @@ namespace NATS.Client
     }
 
     /// <summary>
+    /// The exception that is thrown when there is an error writing
+    /// to the internal reconnect buffer.
+    /// </summary>
+    public class NATSReconnectBufferException : NATSConnectionException
+    {
+        internal NATSReconnectBufferException(string err) : base(err) { }
+    }
+
+    /// <summary>
     /// This exception that is thrown when there is an internal error with
     /// the NATS protocol.
     /// </summary>

--- a/NATS.Client/IConnection.cs
+++ b/NATS.Client/IConnection.cs
@@ -80,6 +80,10 @@ namespace NATS.Client
         /// the current connection.</param>
         /// <param name="data">An array of type <see cref="Byte"/> that contains the data to publish
         /// to the connected NATS server.</param>
+        /// <exception cref="NATSReconnectBufferException"> is thrown when
+        /// publishing while reconnecting and the internal reconnect buffer
+        /// has been disabled or exceeded.</exception>
+        /// <seealso cref="Option.ReconnectBufferSize"></seealso>
         void Publish(string subject, byte[] data);
 
         /// <summary>

--- a/NATS.Client/NATS.cs
+++ b/NATS.Client/NATS.cs
@@ -137,6 +137,11 @@ namespace NATS.Client
         /// </summary>
         public const int DefaultDrainTimeout = 30000;
 
+        /// <summary>
+        /// Default Pending buffer size is 8 MB.
+        /// </summary>
+        public const int ReconnectBufferSize = 8 * 1024 * 1024; // 8MB
+
         /*
          * Namespace level defaults
          */

--- a/NATS.Client/Options.cs
+++ b/NATS.Client/Options.cs
@@ -182,6 +182,7 @@ namespace NATS.Client
 
         // Must be greater than 0.
         internal int subscriptionBatchSize = 64;
+        internal int reconnectBufSize = Defaults.ReconnectBufferSize;
 
         internal string user;
         internal string password;
@@ -208,6 +209,7 @@ namespace NATS.Client
             noRandomize = o.noRandomize;
             noEcho = o.noEcho;
             pedantic = o.pedantic;
+            reconnectBufSize = o.reconnectBufSize;
             useOldRequestStyle = o.useOldRequestStyle;
             pingInterval = o.pingInterval;
             ReconnectedEventHandler = o.ReconnectedEventHandler;
@@ -269,7 +271,7 @@ namespace NATS.Client
         }
 
         /// <summary>
-        /// Gets or sets the array of servers that the NATs client will connect to.
+        /// Gets or sets the array of servers that the NATS client will connect to.
         /// </summary>
         /// <remarks>
         /// The individual URLs may contain username/password information.
@@ -585,6 +587,43 @@ namespace NATS.Client
                 sb.AppendFormat("{0}=null;", name);
         }
 
+
+        /// <summary>
+        /// Constant used to sets the reconnect buffer size to unbounded.
+        /// </summary>
+        /// <seealso cref="ReconnectBufferSize"/>
+        public static readonly int ReconnectBufferSizeUnbounded = 0;
+
+        /// <summary>
+        /// Constant that disables the reconnect buffer.
+        /// </summary>
+        /// <seealso cref="ReconnectBufferSize"/>
+        public static readonly int ReconnectBufferDisabled = -1;
+
+        /// <summary>
+        /// Gets or sets the buffer size of messages kept while busy reconnecting.
+        /// </summary>
+        /// <remarks>
+        /// When reconnecting, the NATS client will hold published messages that
+        /// will be flushed to the new server upon a successful reconnect.  The default
+        /// is buffer size is 8 MB.  This buffering can be disabled.
+        /// </remarks>
+        /// <seealso cref="ReconnectBufferSizeUnbounded"/>
+        /// <seealso cref="ReconnectBufferDisabled"/>
+        public int ReconnectBufferSize
+        {
+            get { return reconnectBufSize; }
+            set
+            {
+                if (value < -1)
+                {
+                    throw new ArgumentOutOfRangeException("value", "Subscription batch size must be greater than -1");
+                }
+
+                reconnectBufSize = value;
+            }
+        }
+
         /// <summary>
         /// Returns a string representation of the
         /// value of this Options instance.
@@ -609,6 +648,7 @@ namespace NATS.Client
             sb.AppendFormat("Pendantic={0};", Pedantic);
             sb.AppendFormat("UseOldRequestStyle={0}", UseOldRequestStyle);
             sb.AppendFormat("PingInterval={0};", PingInterval);
+            sb.AppendFormat("ReconnectBufferSize={0};", ReconnectBufferSize);
             sb.AppendFormat("ReconnectWait={0};", ReconnectWait);
             sb.AppendFormat("Secure={0};", Secure);
             sb.AppendFormat("User={0};", User);

--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -1094,8 +1094,6 @@ namespace NATSUnitTests
         }
 
         /// NOT IMPLEMENTED:
-        /// TestServerSecureConnections
-        /// TestErrOnConnectAndDeadlock
         /// TestErrOnMaxPayloadLimit
 
     } // class


### PR DESCRIPTION
Implement reconnect buffer sizing and disabling, a feature available in the golang client.

Resolves #251.

Signed-off-by: Colin Sullivan <colin@synadia.com>