### PR TITLE
Fixed various typos in comments and field names. Fixed Exception for passing comment correctly

### DIFF
--- a/NATS.Client/EncodedConn.cs
+++ b/NATS.Client/EncodedConn.cs
@@ -114,7 +114,7 @@ namespace NATS.Client
         private IFormatter f = new BinaryFormatter();
 
         // Note, the connection locks around this, so while we are using a
-        // byte array in the connection, we are still threadsafe.
+        // byte array in the connection, we are still thread safe.
         internal byte[] defaultSerializer(Object obj)
         {
             byte[] rv = null;
@@ -143,7 +143,7 @@ namespace NATS.Client
         // it'd be nice to have a default serializer per subscription to avoid
         // the lock here, but this  mirrors go.
         //
-        // TODO:  Look at moving the default to the wrapper and keeping a derialization
+        // TODO:  Look at moving the default to the wrapper and keeping a deserialization
         // stream there.
         internal object defaultDeserializer(byte[] data)
         {
@@ -182,7 +182,7 @@ namespace NATS.Client
         /// <param name="obj">The <see cref="Object"/> to serialize and publish to the connected NATS server.</param>
         /// <exception cref="NATSBadSubscriptionException"><paramref name="subject"/> is 
         /// <c>null</c> or entirely whitespace.</exception>
-        /// <exception cref="NATSMaxPayloadException">The serialzed form of <paramref name="obj"/> exceeds the maximum payload size 
+        /// <exception cref="NATSMaxPayloadException">The serialized form of <paramref name="obj"/> exceeds the maximum payload size 
         /// supported by the NATS server.</exception>
         /// <exception cref="NATSConnectionClosedException">The <see cref="Connection"/> is closed.</exception>
         /// <exception cref="NATSException"><para><see cref="OnSerialize"/> is <c>null</c>.</para>
@@ -204,7 +204,7 @@ namespace NATS.Client
         /// <param name="obj">The <see cref="Object"/> to serialize and publish to the connected NATS server.</param>
         /// <exception cref="NATSBadSubscriptionException"><paramref name="subject"/> is <c>null</c> or
         /// entirely whitespace.</exception>
-        /// <exception cref="NATSMaxPayloadException">The serialzed form of <paramref name="obj"/> exceeds the maximum payload size 
+        /// <exception cref="NATSMaxPayloadException">The serialized form of <paramref name="obj"/> exceeds the maximum payload size 
         /// supported by the NATS server.</exception>
         /// <exception cref="NATSConnectionClosedException">The <see cref="Connection"/> is closed.</exception>
         /// <exception cref="NATSException"><para><see cref="OnSerialize"/> is <c>null</c>.</para>
@@ -359,7 +359,7 @@ namespace NATS.Client
         /// (<c>0</c>).</exception>
         /// <exception cref="NATSBadSubscriptionException"><paramref name="subject"/> is <c>null</c> or
         /// entirely whitespace.</exception>
-        /// <exception cref="NATSMaxPayloadException">The serialzed form of <paramref name="obj"/> exceeds the maximum payload size 
+        /// <exception cref="NATSMaxPayloadException">The serialized form of <paramref name="obj"/> exceeds the maximum payload size 
         /// supported by the NATS server.</exception>
         /// <exception cref="NATSConnectionClosedException">The <see cref="Connection"/> is closed.</exception>
         /// <exception cref="NATSTimeoutException">A timeout occurred while sending the request or receiving the 
@@ -387,7 +387,7 @@ namespace NATS.Client
         /// <returns>A <see cref="Object"/> with the deserialized response from the NATS server.</returns>
         /// <exception cref="NATSBadSubscriptionException"><paramref name="subject"/> is <c>null</c> or 
         /// entirely whitespace.</exception>
-        /// <exception cref="NATSMaxPayloadException">The serialzed form of <paramref name="obj"/> exceeds the maximum payload size 
+        /// <exception cref="NATSMaxPayloadException">The serialized form of <paramref name="obj"/> exceeds the maximum payload size 
         /// supported by the NATS server.</exception>
         /// <exception cref="NATSConnectionClosedException">The <see cref="Connection"/> is closed.</exception>
         /// <exception cref="NATSTimeoutException">A timeout occurred while sending the request or receiving the

--- a/NATS.Client/Exceptions.cs
+++ b/NATS.Client/Exceptions.cs
@@ -123,7 +123,7 @@ namespace NATS.Client
     public class NATSBadSubscriptionException : NATSException
     {
         internal NATSBadSubscriptionException() : base("Subscription is not valid.") { }
-        internal NATSBadSubscriptionException(string s) : base("s") { }
+        internal NATSBadSubscriptionException(string s) : base(s) { }
     }
 
     /// <summary>

--- a/NATS.Client/IConnection.cs
+++ b/NATS.Client/IConnection.cs
@@ -71,8 +71,8 @@ namespace NATS.Client
         /// <para>NATS implements a publish-subscribe message distribution model. NATS publish subscribe is a
         /// one-to-many communication. A publisher sends a message on a subject. Any active subscriber listening
         /// on that subject receives the message. Subscribers can register interest in wildcard subjects.</para>
-        /// <para>In the basic NATS platfrom, if a subscriber is not listening on the subject (no subject match),
-        /// or is not acive when the message is sent, the message is not recieved. NATS is a fire-and-forget
+        /// <para>In the basic NATS platform, if a subscriber is not listening on the subject (no subject match),
+        /// or is not active when the message is sent, the message is not received. NATS is a fire-and-forget
         /// messaging system. If you need higher levels of service, you can either use NATS Streaming, or build the
         /// additional reliability into your client(s) yourself.</para>
         /// </remarks>

--- a/NATS.Client/ISubscription.cs
+++ b/NATS.Client/ISubscription.cs
@@ -45,7 +45,7 @@ namespace NATS.Client
         /// <item>Wildcards must be separate tokens (<c>foo.*.bar</c> or <c>foo.&gt;</c> are syntactically
         /// valid; <c>foo*.bar</c>, <c>f*o.b*r</c> and <c>foo&gt;</c> are not).</item>
         /// </list>
-        /// <para>For example, the wildcard subscrpitions <c>foo.*.quux</c> and <c>foo.&gt;</c> both match
+        /// <para>For example, the wildcard subscriptions <c>foo.*.quux</c> and <c>foo.&gt;</c> both match
         /// <c>foo.bar.quux</c>, but only the latter matches <c>foo.bar.baz</c>. With the full wildcard,
         /// it is also possible to express interest in every subject that may exist in NATS (<c>&gt;</c>).</para>
         /// </remarks>

--- a/NATS.Client/Msg.cs
+++ b/NATS.Client/Msg.cs
@@ -159,10 +159,19 @@ namespace NATS.Client
             this.data = data;
         }
 
-        /// <summary>
-        /// Gets the <see cref="ISubscription"/> which received the message.
-        /// </summary>
-        public ISubscription ArrivalSubscription
+		/// <summary>
+		/// Gets the <see cref="ISubscription"/> which received the message.
+		/// </summary>
+		[ObsoleteAttribute("This property will soon be deprecated. Use ArrivalSubscription instead.")]
+		public ISubscription ArrivalSubcription
+		{
+			get { return sub; }
+		}
+
+		/// <summary>
+		/// Gets the <see cref="ISubscription"/> which received the message.
+		/// </summary>
+		public ISubscription ArrivalSubscription
         {
             get { return sub; }
         }

--- a/NATS.Client/Msg.cs
+++ b/NATS.Client/Msg.cs
@@ -162,7 +162,7 @@ namespace NATS.Client
         /// <summary>
         /// Gets the <see cref="ISubscription"/> which received the message.
         /// </summary>
-        public ISubscription ArrivalSubcription
+        public ISubscription ArrivalSubscription
         {
             get { return sub; }
         }
@@ -174,7 +174,7 @@ namespace NATS.Client
         /// <exception cref="NATSException">
         /// <para><see cref="Reply"/> is null or empty.</para>
         /// <para>-or-</para>
-        /// <para><see cref="ArrivalSubcription"/> is null.</para>
+        /// <para><see cref="ArrivalSubscription"/> is null.</para>
         /// </exception>
         public void Respond(byte[] data)
         {
@@ -183,7 +183,7 @@ namespace NATS.Client
                 throw new NATSException("No Reply subject");
             }
 
-            Connection conn = ArrivalSubcription?.Connection;
+            Connection conn = ArrivalSubscription?.Connection;
             if (conn == null)
             {
                 throw new NATSException("Message is not bound to a subscription");

--- a/NATS.Client/Msg.cs
+++ b/NATS.Client/Msg.cs
@@ -159,19 +159,19 @@ namespace NATS.Client
             this.data = data;
         }
 
-		/// <summary>
-		/// Gets the <see cref="ISubscription"/> which received the message.
-		/// </summary>
-		[ObsoleteAttribute("This property will soon be deprecated. Use ArrivalSubscription instead.")]
-		public ISubscription ArrivalSubcription
-		{
-			get { return sub; }
-		}
+        /// <summary>
+        /// Gets the <see cref="ISubscription"/> which received the message.
+        /// </summary>
+        [ObsoleteAttribute("This property will soon be deprecated. Use ArrivalSubscription instead.")]
+        public ISubscription ArrivalSubcription
+        {
+            get { return sub; }
+        }
 
-		/// <summary>
-		/// Gets the <see cref="ISubscription"/> which received the message.
-		/// </summary>
-		public ISubscription ArrivalSubscription
+        /// <summary>
+        /// Gets the <see cref="ISubscription"/> which received the message.
+        /// </summary>
+        public ISubscription ArrivalSubscription
         {
             get { return sub; }
         }

--- a/NATS.Client/NATS.cs
+++ b/NATS.Client/NATS.cs
@@ -240,7 +240,7 @@ namespace NATS.Client
             {
                 if (signedNonce == null)
                 {
-                    throw new NATSConnectionException("SignedNonce was not set by the UserSignature event hander.");
+                    throw new NATSConnectionException("SignedNonce was not set by the UserSignature event handler.");
                 }
                 return signedNonce;
             }

--- a/NATS.Client/Options.cs
+++ b/NATS.Client/Options.cs
@@ -151,7 +151,7 @@ namespace NATS.Client
         /// sign the server nonce.
         /// </summary>
         /// <param name="publicNkey">The User's public Nkey</param>
-        /// <param name="privateKeyPath">A path to a file contianing the private Nkey.</param>
+        /// <param name="privateKeyPath">A path to a file containing the private Nkey.</param>
         public void SetNkey(string publicNkey, string privateKeyPath)
         {
             if (string.IsNullOrWhiteSpace(publicNkey)) throw new ArgumentException("Invalid publicNkey", nameof(publicNkey));
@@ -462,12 +462,12 @@ namespace NATS.Client
         }
 
         /// <summary>
-        /// Adds an X.509 certifcate from a file for use with a secure connection.
+        /// Adds an X.509 certificate from a file for use with a secure connection.
         /// </summary>
         /// <param name="fileName">Path to the certificate file to add.</param>
         /// <exception cref="ArgumentNullException"><paramref name="fileName"/> is <c>null</c>.</exception>
         /// <exception cref="System.Security.Cryptography.CryptographicException">An error with the certificate
-        /// ocurred. For example:
+        /// occurred. For example:
         /// <list>
         /// <item>The certificate file does not exist.</item>
         /// <item>The certificate is invalid.</item>
@@ -481,12 +481,12 @@ namespace NATS.Client
         }
 
         /// <summary>
-        /// Adds an X.509 certifcate for use with a secure connection.
+        /// Adds an X.509 certificate for use with a secure connection.
         /// </summary>
         /// <param name="certificate">An X.509 certificate represented as an <see cref="X509Certificate2"/> object.</param>
         /// <exception cref="ArgumentNullException"><paramref name="certificate"/> is <c>null</c>.</exception>
         /// <exception cref="System.Security.Cryptography.CryptographicException">An error with the certificate
-        /// ocurred. For example:
+        /// occurred. For example:
         /// <list>
         /// <item>The certificate file does not exist.</item>
         /// <item>The certificate is invalid.</item>

--- a/NATS.Client/ServerPool.cs
+++ b/NATS.Client/ServerPool.cs
@@ -66,7 +66,7 @@ namespace NATS.Client
 
         // Create the server pool using the options given.
         // We will place a Url option first, followed by any
-        // Server Options. We will randomize the server pool unlesss
+        // Server Options. We will randomize the server pool unless
         // the NoRandomize flag is set.
         internal void Setup(Options opts)
         {
@@ -220,7 +220,7 @@ namespace NATS.Client
             }
         }
 
-        // removes implict servers NOT found in the provided list. 
+        // removes implicit servers NOT found in the provided list. 
         internal void PruneOutdatedServers(string[] newUrls)
         {
             LinkedList<string> ulist = new LinkedList<string>(newUrls);
@@ -235,7 +235,7 @@ namespace NATS.Client
                 foreach (Srv s in tmp)
                 {
                     // The server returns "<host>:<port>".  We can't compare
-                    // againts Uri.Authority becase that API may strip out 
+                    // against Uri.Authority because that API may strip out 
                     // ports.
                     string hp = string.Format("{0}:{1}", s.url.Host, s.url.Port);
                     if (s.isImplicit && !ulist.Contains(hp) &&

--- a/NATS.Client/Statistics.cs
+++ b/NATS.Client/Statistics.cs
@@ -70,7 +70,7 @@ namespace NATS.Client
             get {  return reconnects; }
         }
 
-        // deep copy contructor
+        // deep copy constructor
         internal Statistics(Statistics obj)
         {
             this.inMsgs = obj.inMsgs;

--- a/NATSUnitTests/UnitTestBasic.cs
+++ b/NATSUnitTests/UnitTestBasic.cs
@@ -247,7 +247,7 @@ namespace NATSUnitTests
         private void CheckReceivedAndValidHandler(object sender, MsgHandlerEventArgs args)
         {
             Assert.True(compare(args.Message.Data, omsg), "Messages are not equal.");
-            Assert.Equal(asyncSub, args.Message.ArrivalSubcription);
+            Assert.Equal(asyncSub, args.Message.ArrivalSubscription);
 
             lock (mu)
             {

--- a/NATSUnitTests/UnitTestConn.cs
+++ b/NATSUnitTests/UnitTestConn.cs
@@ -823,7 +823,7 @@ namespace NATSUnitTests
                 c.Drain();
 
                 done.WaitOne(5000);
-                Assert.True(received == expected, string.Format("recieved {0} of {1}", received, expected));
+                Assert.True(received == expected, string.Format("received {0} of {1}", received, expected));
             }
         }
 
@@ -863,7 +863,7 @@ namespace NATSUnitTests
                 t.Wait();
 
                 done.WaitOne(5000);
-                Assert.True(received == expected, string.Format("recieved {0} of {1}", received, expected));
+                Assert.True(received == expected, string.Format("received {0} of {1}", received, expected));
             }
         }
 
@@ -897,7 +897,7 @@ namespace NATSUnitTests
                 s.Drain();
 
                 done.WaitOne(5000);
-                Assert.True(received == expected, string.Format("recieved {0} of {1}", received, expected));
+                Assert.True(received == expected, string.Format("received {0} of {1}", received, expected));
             }
         }
 
@@ -937,7 +937,7 @@ namespace NATSUnitTests
                 t.Wait();
 
                 done.WaitOne(5000);
-                Assert.True(received == expected, string.Format("recieved {0} of {1}", received, expected));
+                Assert.True(received == expected, string.Format("received {0} of {1}", received, expected));
             }
         }
 


### PR DESCRIPTION
- Fixed various typos in comments
- Fixed the naming of a field. ArrivalSubscription had a typo
- Fixed bug in NATSBadSubscriptionException.
- The passed error message was never forwarded to the NATSException container
