### PR TITLE
Fixes so that SemVer is not pre-release when build is against master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,9 +4,10 @@ variables:
   Ver: '0.9.0'
   BuildRev: $[counter(variables.Ver, 1)]
   BuildVer: $[ format('{0}.{1}', variables.Ver, variables.BuildRev) ]
-  SemVer: $[ format('{0}-pre{1}', variables.Ver, variables.BuildRev) ]
-  ${{ if eq( variables.Build.SourceBranchName, 'master' ) }}:
-    SemVer: ${{$(Ver)}}
+  ${{ if eq( variables['Build.SourceBranchName'], 'master' ) }}:
+    SemVer: $[ variables.Ver ]
+  ${{ if ne( variables['Build.SourceBranchName'], 'master' ) }}:
+    SemVer: $[ format('{0}-pre{1}', variables.Ver, variables.BuildRev) ]
 
 trigger:
 - master


### PR DESCRIPTION
When the PR #288 was merged into `master` yesterday, I noticed the pipeline generated the wrong `SemVer` as it was counted as a pre-release. The idea is that against `master` it is seen as a stable release.