### PR TITLE
Changes test class names

### DIFF
--- a/src/Tests/IntegrationTests/AuthorizationTests.cs
+++ b/src/Tests/IntegrationTests/AuthorizationTests.cs
@@ -24,9 +24,9 @@ namespace IntegrationTests
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    public class TestAuthorization : TestSuite<AuthorizationSuiteContext>
+    public class AuthorizationTests : TestSuite<AuthorizationTestsContext>
     {
-        public TestAuthorization(AuthorizationSuiteContext context) : base(context) { }
+        public AuthorizationTests(AuthorizationTestsContext context) : base(context) { }
 
         int hitDisconnect;
 

--- a/src/Tests/IntegrationTests/BasicTests.cs
+++ b/src/Tests/IntegrationTests/BasicTests.cs
@@ -26,10 +26,10 @@ namespace IntegrationTests
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    [Collection(DefaultSuiteContext.CollectionKey)]
-    public class TestBasic : TestSuite<DefaultSuiteContext>
+    [Collection(DefaultTestsContext.CollectionKey)]
+    public class BasicTests : TestSuite<DefaultTestsContext>
     {
-        public TestBasic(DefaultSuiteContext context) : base(context) { }
+        public BasicTests(DefaultTestsContext context) : base(context) { }
 
         [Fact]
         public void TestConnectedServer()
@@ -604,7 +604,7 @@ namespace IntegrationTests
             }
         }
 
-        private async void testRequestAsync(bool useOldRequestStyle)
+        private async Task testRequestAsync(bool useOldRequestStyle)
         {
             using (NATSServer.CreateFastAndVerify())
             {
@@ -640,7 +640,7 @@ namespace IntegrationTests
             }
         }
 
-        private async void testRequestAsyncWithOffsets(bool useOldRequestStyle)
+        private async Task testRequestAsyncWithOffsets(bool useOldRequestStyle)
         {
             using (NATSServer.CreateFastAndVerify())
             {
@@ -680,30 +680,30 @@ namespace IntegrationTests
         }
 
         [Fact]
-        public void TestRequestAsync()
+        public async Task TestRequestAsync()
         {
-            testRequestAsync(useOldRequestStyle: false);
+            await testRequestAsync(useOldRequestStyle: false);
         }
 
         [Fact]
-        public void TestRequestAsync_OldRequestStyle()
+        public async Task TestRequestAsync_OldRequestStyle()
         {
-            testRequestAsync(useOldRequestStyle: true);
+            await testRequestAsync(useOldRequestStyle: true);
         }
 
         [Fact]
-        public void TestRequestAsyncWithOffsets()
+        public async Task TestRequestAsyncWithOffsets()
         {
-            testRequestAsyncWithOffsets(useOldRequestStyle: false);
+            await testRequestAsyncWithOffsets(useOldRequestStyle: false);
         }
 
         [Fact]
-        public void TestRequestAsyncWithOffsets_OldRequestStyle()
+        public async Task TestRequestAsyncWithOffsets_OldRequestStyle()
         {
-            testRequestAsyncWithOffsets(useOldRequestStyle: true);
+            await testRequestAsyncWithOffsets(useOldRequestStyle: true);
         }
 
-        private async void testRequestAsyncCancellation(bool useOldRequestStyle)
+        private async Task testRequestAsyncCancellation(bool useOldRequestStyle)
         {
             using (NATSServer.CreateFastAndVerify())
             {
@@ -778,18 +778,18 @@ namespace IntegrationTests
         }
 
         [Fact]
-        public void TestRequestAsyncCancellation()
+        public async Task TestRequestAsyncCancellation()
         {
-            testRequestAsyncCancellation(useOldRequestStyle: false);
+            await testRequestAsyncCancellation(useOldRequestStyle: false);
         }
 
         [Fact]
-        public void TestRequestAsyncCancellation_OldRequestStyle()
+        public async Task TestRequestAsyncCancellation_OldRequestStyle()
         {
-            testRequestAsyncCancellation(useOldRequestStyle: true);
+            await testRequestAsyncCancellation(useOldRequestStyle: true);
         }
 
-        private async void testRequestAsyncTimeout(bool useOldRequestStyle)
+        private async Task testRequestAsyncTimeout(bool useOldRequestStyle)
         {
             using (var server = NATSServer.CreateFastAndVerify())
             {
@@ -808,7 +808,7 @@ namespace IntegrationTests
                 sw.Start();
                 await conn.RequestAsync("foo", new byte[0], 5000);
                 sw.Stop();
-                Assert.True(sw.ElapsedMilliseconds < 5000, "Unexpected timeout behavior");
+                Assert.True(sw.ElapsedMilliseconds < 5000, $"Unexpected timeout behavior. Expected lt 5000ms got {sw.ElapsedMilliseconds}ms");
                 sub.Unsubscribe();
 
                 // valid connection, but no response
@@ -832,15 +832,15 @@ namespace IntegrationTests
         }
 
         [Fact]
-        public void TestRequestAsyncTimeout()
+        public async Task TestRequestAsyncTimeout()
         {
-            testRequestAsyncTimeout(useOldRequestStyle: false);
+            await testRequestAsyncTimeout(useOldRequestStyle: false);
         }
 
         [Fact]
-        public void TestRequestAsyncTimeout_OldRequestStyle()
+        public async Task TestRequestAsyncTimeout_OldRequestStyle()
         {
-            testRequestAsyncTimeout(useOldRequestStyle: true);
+            await testRequestAsyncTimeout(useOldRequestStyle: true);
         }
 
         class TestReplier

--- a/src/Tests/IntegrationTests/ClusterTests.cs
+++ b/src/Tests/IntegrationTests/ClusterTests.cs
@@ -24,9 +24,9 @@ namespace IntegrationTests
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    public class TestCluster : TestSuite<ClusterSuiteContext>
+    public class ClusterTests : TestSuite<ClusterTestsContext>
     {
-        public TestCluster(ClusterSuiteContext context) : base(context) { }
+        public ClusterTests(ClusterTestsContext context) : base(context) { }
 
         [Fact]
         public void TestServersOption()

--- a/src/Tests/IntegrationTests/ConnectionTests.cs
+++ b/src/Tests/IntegrationTests/ConnectionTests.cs
@@ -19,9 +19,9 @@ using System.Diagnostics;
 
 namespace IntegrationTests
 {
-    public class TestConnection : TestSuite<ConnectionSuiteContext>
+    public class ConnectionTests : TestSuite<ConnectionTestsContext>
     {
-        public TestConnection(ConnectionSuiteContext context) : base(context) { }
+        public ConnectionTests(ConnectionTestsContext context) : base(context) { }
 
         [Fact]
         public void TestConnectionStatus()
@@ -457,9 +457,9 @@ namespace IntegrationTests
         /// TestErrOnMaxPayloadLimit
     }
 
-    public class TestConnectionSecurity : TestSuite<ConnectionSecuritySuiteContext>
+    public class ConnectionSecurityTests : TestSuite<ConnectionSecurityTestsContext>
     {
-        public TestConnectionSecurity(ConnectionSecuritySuiteContext context) : base(context) { }
+        public ConnectionSecurityTests(ConnectionSecurityTestsContext context) : base(context) { }
 
         [Fact]
         public void TestNKey()
@@ -660,9 +660,9 @@ namespace IntegrationTests
         }
     }
 
-    public class TestConnectionDrain : TestSuite<ConnectionDrainSuiteContext>
+    public class ConnectionDrainTests : TestSuite<ConnectionDrainTestsContext>
     {
-        public TestConnectionDrain(ConnectionDrainSuiteContext context) : base(context) { }
+        public ConnectionDrainTests(ConnectionDrainTestsContext context) : base(context) { }
 
         [Fact]
         public void TestDrain()
@@ -859,7 +859,7 @@ namespace IntegrationTests
                 sw.Stop();
 
                 // add slack for slow CI.
-                Assert.True(sw.ElapsedMilliseconds >= 1000);
+                Assert.True(sw.ElapsedMilliseconds >= 1000, $"Expected elapsed ms to be gte 1000ms but got {sw.ElapsedMilliseconds}ms");
             }
         }
 
@@ -884,7 +884,7 @@ namespace IntegrationTests
                 sw.Stop();
 
                 // add slack for slow CI.
-                Assert.True(sw.ElapsedMilliseconds >= 500);
+                Assert.True(sw.ElapsedMilliseconds >= 500, $"Expected elapsed ms to be gte 500ms but got {sw.ElapsedMilliseconds}ms");
             }
         }
 
@@ -963,9 +963,9 @@ namespace IntegrationTests
         }
     }
 
-    public class TestConnectionMemoryLeaks : TestSuite<ConnectionMemoryLeaksSuiteContext>
+    public class ConnectionMemoryLeakTests : TestSuite<ConnectionMemoryLeakTestsContext>
     {
-        public TestConnectionMemoryLeaks(ConnectionMemoryLeaksSuiteContext context) : base(context) { }
+        public ConnectionMemoryLeakTests(ConnectionMemoryLeakTestsContext context) : base(context) { }
 
 #if memcheck
         [Fact]

--- a/src/Tests/IntegrationTests/EncodingTests.cs
+++ b/src/Tests/IntegrationTests/EncodingTests.cs
@@ -25,9 +25,9 @@ namespace IntegrationTests
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    public class TestEncoding : TestSuite<EncodingSuiteContext>
+    public class EncodingTests : TestSuite<EncodingTestsContext>
     {
-        public TestEncoding(EncodingSuiteContext context) : base(context) { }
+        public EncodingTests(EncodingTestsContext context) : base(context) { }
 
         public IEncodedConnection DefaultEncodedConnection => Context.OpenEncodedConnectionWithDefaultTimeout(Context.Server1.Port);
 

--- a/src/Tests/IntegrationTests/ReconnectTests.cs
+++ b/src/Tests/IntegrationTests/ReconnectTests.cs
@@ -22,9 +22,9 @@ using Xunit;
 
 namespace IntegrationTests
 {
-    public class TestReconnect : TestSuite<ReconnectSuiteContext>
+    public class ReconnectTests : TestSuite<ReconnectTestsContext>
     {
-        public TestReconnect(ReconnectSuiteContext context) : base(context) { }
+        public ReconnectTests(ReconnectTestsContext context) : base(context) { }
 
         private Options getReconnectOptions()
         {
@@ -477,9 +477,9 @@ namespace IntegrationTests
         }
     }
 
-    public class TestPublishErrorsDuringReconnect : TestSuite<PublishErrorsDuringReconnectSuiteContext>
+    public class ReconnectPublishErrorsTests : TestSuite<ReconnectPublishErrorsTestsContext>
     {
-        public TestPublishErrorsDuringReconnect(PublishErrorsDuringReconnectSuiteContext context)
+        public ReconnectPublishErrorsTests(ReconnectPublishErrorsTestsContext context)
             : base(context) { }
 
         [Fact]

--- a/src/Tests/IntegrationTests/SubscriptionTests.cs
+++ b/src/Tests/IntegrationTests/SubscriptionTests.cs
@@ -25,9 +25,9 @@ namespace IntegrationTests
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    public class TestSubscriptions : TestSuite<SubscriptionsSuiteContext>
+    public class SubscriptionTests : TestSuite<SubscriptionsTestsContext>
     {
-        public TestSubscriptions(SubscriptionsSuiteContext context) : base(context) { }
+        public SubscriptionTests(SubscriptionsTestsContext context) : base(context) { }
 
         [Fact]
         public void TestServerAutoUnsub()

--- a/src/Tests/IntegrationTests/TestSuite.cs
+++ b/src/Tests/IntegrationTests/TestSuite.cs
@@ -37,7 +37,7 @@ namespace IntegrationTests
 
         public const int AuthorizationSuite = 11490; //3pc
         public const int ReconnectSuite = 11493; //1pc
-        public const int PublishErrorsDuringReconnectSuite = 11494; //1pc
+        public const int ReconnectPublishErrorsSuite = 11494; //1pc
         public const int ClusterSuite = 11495; //10pc
         public const int ConnectionSuite = 11505;//2pc
         public const int ConnectionSecuritySuite = 11507; //1pc
@@ -85,7 +85,7 @@ namespace IntegrationTests
         }
     }
 
-    public class DefaultSuiteContext : SuiteContext
+    public class DefaultTestsContext : SuiteContext
     {
         public const string CollectionKey = "9733f463316047fa9207e0a3aaa3c41a";
 
@@ -112,7 +112,7 @@ namespace IntegrationTests
         public readonly TestServerInfo ClusterServer7 = new TestServerInfo(SeedPortClusterServers + 6);
     }
 
-    public class AuthorizationSuiteContext : SuiteContext
+    public class AuthorizationTestsContext : SuiteContext
     {
         private const int SeedPort = TestSeedPorts.AuthorizationSuite;
 
@@ -121,7 +121,7 @@ namespace IntegrationTests
         public readonly TestServerInfo Server3 = new TestServerInfo(SeedPort + 2);
     }
 
-    public class ConnectionSuiteContext : SuiteContext
+    public class ConnectionTestsContext : SuiteContext
     {
         private const int SeedPort = TestSeedPorts.ConnectionSuite;
 
@@ -129,21 +129,21 @@ namespace IntegrationTests
         public readonly TestServerInfo Server2 = new TestServerInfo(SeedPort + 1);
     }
 
-    public class ConnectionSecuritySuiteContext : SuiteContext
+    public class ConnectionSecurityTestsContext : SuiteContext
     {
         private const int SeedPort = TestSeedPorts.ConnectionSecuritySuite;
 
         public readonly TestServerInfo Server1 = new TestServerInfo(SeedPort);
     }
 
-    public class ConnectionDrainSuiteContext : SuiteContext
+    public class ConnectionDrainTestsContext : SuiteContext
     {
         private const int SeedPort = TestSeedPorts.ConnectionDrainSuite;
 
         public readonly TestServerInfo Server1 = new TestServerInfo(SeedPort);
     }
 
-    public class ConnectionMemoryLeaksSuiteContext : SuiteContext
+    public class ConnectionMemoryLeakTestsContext : SuiteContext
     {
         private const int SeedPort = TestSeedPorts.ConnectionMemoryLeaksSuite;
 
@@ -152,7 +152,7 @@ namespace IntegrationTests
         public readonly TestServerInfo Server3 = new TestServerInfo(SeedPort + 2);
     }
 
-    public class ClusterSuiteContext : SuiteContext
+    public class ClusterTestsContext : SuiteContext
     {
         private const int SeedPort = TestSeedPorts.ClusterSuite;
 
@@ -170,7 +170,7 @@ namespace IntegrationTests
         public readonly TestServerInfo[] TestServers;
         public readonly TestServerInfo[] TestServersShortList;
 
-        public ClusterSuiteContext()
+        public ClusterTestsContext()
         {
             TestServers = new[]
             {
@@ -192,35 +192,35 @@ namespace IntegrationTests
         public string[] GetTestServersShortListUrls() => TestServersShortList.Select(s => s.Url).ToArray();
     }
 
-    public class EncodingSuiteContext : SuiteContext
+    public class EncodingTestsContext : SuiteContext
     {
         private const int SeedPort = TestSeedPorts.EncodingSuite;
 
         public readonly TestServerInfo Server1 = new TestServerInfo(SeedPort);
     }
 
-    public class ReconnectSuiteContext : SuiteContext
+    public class ReconnectTestsContext : SuiteContext
     {
         private const int SeedPort = TestSeedPorts.ReconnectSuite;
 
         public readonly TestServerInfo Server1 = new TestServerInfo(SeedPort);
     }
 
-    public class PublishErrorsDuringReconnectSuiteContext : SuiteContext
+    public class ReconnectPublishErrorsTestsContext : SuiteContext
     {
-        private const int SeedPort = TestSeedPorts.PublishErrorsDuringReconnectSuite;
+        private const int SeedPort = TestSeedPorts.ReconnectPublishErrorsSuite;
 
         public readonly TestServerInfo Server1 = new TestServerInfo(SeedPort);
     }
 
-    public class SubscriptionsSuiteContext : SuiteContext
+    public class SubscriptionsTestsContext : SuiteContext
     {
         private const int SeedPort = TestSeedPorts.SubscriptionsSuite;
 
         public readonly TestServerInfo Server1 = new TestServerInfo(SeedPort);
     }
 
-    public class TlsSuiteContext : SuiteContext
+    public class TlsTestsContext : SuiteContext
     {
         private const int SeedPort = TestSeedPorts.TlsSuite;
 

--- a/src/Tests/IntegrationTests/TlsTests.cs
+++ b/src/Tests/IntegrationTests/TlsTests.cs
@@ -26,9 +26,9 @@ namespace IntegrationTests
     /// <summary>
     /// Run these tests with the gnatsd auth.conf configuration file.
     /// </summary>
-    public class TestTls : TestSuite<TlsSuiteContext>
+    public class TlsTests : TestSuite<TlsTestsContext>
     {
-        public TestTls(TlsSuiteContext context) : base(context) { }
+        public TlsTests(TlsTestsContext context) : base(context) { }
 
         // A hack to avoid issues with our test self signed cert.
         // We don't want to require the runner of the test to install the 

--- a/src/Tests/UnitTests/NuidTests.cs
+++ b/src/Tests/UnitTests/NuidTests.cs
@@ -19,7 +19,7 @@ using Xunit;
 
 namespace UnitTests
 {
-    public class TestNUID
+    public class NuidTests
     {
         [Fact]
         public void TestGlobalNUID()

--- a/src/Tests/UnitTests/OptionTests.cs
+++ b/src/Tests/UnitTests/OptionTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace UnitTests
 {
-    public class TestOptions
+    public class OptionTests
     {
         private Options GetDefaultOptions() => ConnectionFactory.GetDefaultOptions();
 

--- a/src/Tests/UnitTests/SubscriptionTests.cs
+++ b/src/Tests/UnitTests/SubscriptionTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace UnitTests
 {
-    public class TestSubscriptions
+    public class SubscriptionTests
     {
         static readonly string[] invalidSubjects = { "foo bar", "foo..bar", ".foo", "bar.baz.", "baz\t.foo" };
         static readonly string[] invalidQNames = { "foo group", "group\t1", "g1\r\n2" };


### PR DESCRIPTION
This was something we discussed in PR #292 Changes the test names to read better. Also updates async tests to return Tasks and adds some assert info to some flaky tests.

After the rename, I actually started to get some flaky tests reported in the CI pipeline. But sinze they all had the same prefix `Test` before, the order or anything should not have changed. And the order is anyhow now not that important since we run them in parallel against different ports.

Coincidence? Opinions?