### PR TITLE
Removes unnecessary sync over async for Drain and the lock

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -3929,6 +3929,11 @@ namespace NATS.Client
             if (timeout <= 0)
                 throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be greater than zero.");
 
+            lock (mu)
+            {
+                status = ConnState.DRAINING_SUBS;
+            }
+
             drain(timeout);
         }
 
@@ -3968,6 +3973,11 @@ namespace NATS.Client
         {
             if (timeout <= 0)
                 throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be greater than zero.");
+
+            lock (mu)
+            {
+                status = ConnState.DRAINING_SUBS;
+            }
 
             return Task.Run(() => drain(timeout));
         }

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -3908,15 +3908,7 @@ namespace NATS.Client
         /// <seealso cref="Close()"/>
         public void Drain()
         {
-            var t = DrainAsync();
-            try
-            {
-                t.Wait();
-            }
-            catch (AggregateException)
-            {
-                throw new NATSTimeoutException();
-            }
+            Drain(Defaults.DefaultDrainTimeout);
         }
 
         /// <summary>
@@ -3934,15 +3926,10 @@ namespace NATS.Client
         /// <param name="timeout">The duration to wait before draining.</param> 
         public void Drain(int timeout)
         {
-            var t = DrainAsync(timeout);
-            try
-            {
-                t.Wait();
-            }
-            catch (AggregateException)
-            {
-                throw new NATSTimeoutException();
-            }
+            if (timeout <= 0)
+                throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be greater than zero.");
+
+            drain(timeout);
         }
 
         /// <summary>
@@ -3981,11 +3968,6 @@ namespace NATS.Client
         {
             if (timeout <= 0)
                 throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be greater than zero.");
-
-            lock (mu)
-            {
-                status = ConnState.DRAINING_SUBS;
-            }
 
             return Task.Run(() => drain(timeout));
         }


### PR DESCRIPTION
The entrypoint `DrainAsync` code calls into sync code via a new task, so the sync entrypoint `Drain` should be able to not go via the `Async` member. That way we reduce a sync-over-async usage and `Wait` call. I know the risk has been removed since the async member creates it's own task so deadlocks should not be an issue. How-ever, I do believe creating Tasks and introducing blocking Waits should be kept to a minimum.

Also removes the `lock` for switching status as that is done in the inner `drain` member.