### PR TITLE
Removes duplicate call to kickFlusher

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -892,7 +892,6 @@ namespace NATS.Client
         {
             // Kick old flusher forcefully.
             setFlusherDone(true);
-            kickFlusher();
 
             if (wg.Count > 0)
             {


### PR DESCRIPTION
`setFlusherDone(true)` already causes `kickFlusher` to run. Or is this done to be "sure" `kickFlusher` is called e.g. if someone refactors something that isn't caught by tests?