### PR TITLE
Uses ConcurrentQueue instead of manual locking for pongs

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -3494,9 +3494,6 @@ namespace NATS.Client
         // call outstanding and we call close.
         private bool removeFlushEntry(SingleUseChannel<bool> chan)
         {
-            if (pongs.Count == 0)
-                return false;
-
             if (!pongs.TryDequeue(out var start))
                 return false;
 

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -142,7 +142,7 @@ namespace NATS.Client
         private ConcurrentDictionary<Int64, Subscription> subs = 
             new ConcurrentDictionary<Int64, Subscription>();
         
-        private Queue<SingleUseChannel<bool>> pongs = new Queue<SingleUseChannel<bool>>();
+        private readonly ConcurrentQueue<SingleUseChannel<bool>> pongs = new ConcurrentQueue<SingleUseChannel<bool>>();
 
         internal MsgArg   msgArgs = new MsgArg();
 
@@ -764,7 +764,6 @@ namespace NATS.Client
         internal Connection(Options options)
         {
             opts = new Options(options);
-            pongs = createPongs();
 
             PING_P_BYTES = Encoding.UTF8.GetBytes(IC.pingProto);
             PING_P_BYTES_LEN = PING_P_BYTES.Length;
@@ -916,9 +915,7 @@ namespace NATS.Client
                     return;
                 }
 
-                pout++;
-
-                if (pout > Opts.MaxPingsOut)
+                if (Interlocked.Increment(ref pout) > Opts.MaxPingsOut)
                 {
                     processOpError(new NATSStaleConnectionException());
                     return;
@@ -950,7 +947,7 @@ namespace NATS.Client
         // caller must lock
         private void startPingTimer()
         {
-            pout = 0;
+            Interlocked.Exchange(ref pout, 0);
 
             stopPingTimer();
 
@@ -1075,11 +1072,6 @@ namespace NATS.Client
                     return srvPool.GetServerList(true);
                 }
             }
-        }
-
-        private Queue<SingleUseChannel<bool>> createPongs()
-        {
-            return new Queue<SingleUseChannel<bool>>();
         }
 
         // Process a connected connection and initialize properly.
@@ -2212,20 +2204,11 @@ namespace NATS.Client
         // processPong is used to process responses to the client's ping
         // messages. We use pings for the flush mechanism as well.
         internal void processPong()
-        {
-            SingleUseChannel<bool> ch = null;
-            lock (mu)
-            {
-                if (pongs.Count > 0)
-                    ch = pongs.Dequeue();
+        { 
+            if (pongs.TryDequeue(out var ch))
+                ch?.add(true);
 
-                pout = 0;
-            }
-
-            if (ch != null)
-            {
-                ch.add(true);
-            }
+            Interlocked.Exchange(ref pout, 0);
         }
 
         // processOK is a placeholder for processing OK messages.
@@ -3511,14 +3494,13 @@ namespace NATS.Client
         // call outstanding and we call close.
         private bool removeFlushEntry(SingleUseChannel<bool> chan)
         {
-            if (pongs == null)
-                return false;
-
             if (pongs.Count == 0)
                 return false;
 
-            SingleUseChannel<bool> start = pongs.Dequeue();
-            SingleUseChannel<bool> c = start;
+            if (!pongs.TryDequeue(out var start))
+                return false;
+
+            var c = start;
 
             while (true)
             {
@@ -3527,12 +3509,11 @@ namespace NATS.Client
                     SingleUseChannel<bool>.Return(c);
                     return true;
                 }
-                else
-                {
-                    pongs.Enqueue(c);
-                }
 
-                c = pongs.Dequeue();
+                pongs.Enqueue(c);
+
+                if (!pongs.TryDequeue(out c))
+                    return false;
 
                 if (c == start)
                     break;
@@ -3669,14 +3650,8 @@ namespace NATS.Client
         // Lock must be held by the caller.
         private void clearPendingFlushCalls()
         {
-
-            // Clear any queued pongs, e.g. pending flush calls.
-            foreach (SingleUseChannel<bool> ch in pongs)
-            {
-                if (ch != null)
-                    ch.add(true);
-            }
-            pongs.Clear();
+            while(pongs.TryDequeue(out var ch))
+                ch?.add(true);
         }
 
 


### PR DESCRIPTION
Uses `ConcurrentQueue` and `Interlocked` instead of manual locking which e.g. should solve #268

Regarding performance: https://docs.microsoft.com/en-us/dotnet/standard/collections/thread-safe/when-to-use-a-thread-safe-collection#concurrentqueuet-vs-queuet

Did some testing with Benchmark DotNet having parallel producer and consumer working with a `lock` and normal `Queue` and one with no locks and `ConcurrentQueue` and didn't see any real difference in speed as well as memory consumption: https://gist.github.com/danielwertheim/23ca65dc73cf6c4f24e6241c340b49b0