### PR TITLE
Adds Nito for .NET Core app 3.0

### DIFF
--- a/src/Tests/IntegrationTests/IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/IntegrationTests.csproj
@@ -20,6 +20,10 @@
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\NATS.Client\NATS.Client.csproj" />
   </ItemGroup>

--- a/src/Tests/IntegrationTests/TestAsyncAwaitDeadlocks.cs
+++ b/src/Tests/IntegrationTests/TestAsyncAwaitDeadlocks.cs
@@ -1,8 +1,8 @@
-﻿
-using NATS.Client;
-#if !NET452
+﻿#if !NET452
+
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
+using NATS.Client;
 using Nito.AsyncEx;
 using Xunit;
 


### PR DESCRIPTION
After merge to `master` the `netcoreapp3.0` PR and `Nito` PR got merged causing a dependency "miss". This PR fixes that.