### PR TITLE
Manually redo of previous reconnect-buffer PR

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2435,7 +2435,7 @@ namespace NATS.Client
                         else
                             kickFlusher();
 
-                        if (pending.Position + count + pubProtoLen > rbsize)
+                        if (bw.Position + count + pubProtoLen > rbsize)
                             throw new NATSReconnectBufferException("Reconnect buffer exceeded.");
                     }
                 }

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2419,6 +2419,28 @@ namespace NATS.Client
                 // write our pubProtoBuf buffer to the buffered writer.
                 int pubProtoLen = writePublishProto(pubProtoBuf, subject, reply, count);
 
+                // Check if we are reconnecting, and if so check if
+                // we have exceeded our reconnect outbound buffer limits.
+                // Don't use IsReconnecting to avoid locking.
+                if (status == ConnState.RECONNECTING)
+                {
+                    int rbsize = opts.ReconnectBufferSize;
+                    if (rbsize != 0)
+                    {
+                        if (rbsize == -1)
+                        {
+                            throw new NATSReconnectBufferException("Reconnect buffering has been disabled.");
+                        }
+
+                        bw.Flush();
+
+                        if (pending.Position + count + pubProtoLen > rbsize)
+                        {
+                            throw new NATSReconnectBufferException("Reconnect buffer exceed.");
+                        }
+                    }
+                }
+
                 bw.Write(pubProtoBuf, 0, pubProtoLen);
 
                 if (count > 0)

--- a/src/NATS.Client/Exceptions.cs
+++ b/src/NATS.Client/Exceptions.cs
@@ -36,6 +36,15 @@ namespace NATS.Client
     }
 
     /// <summary>
+    /// The exception that is thrown when there is an error writing
+    /// to the internal reconnect buffer.
+    /// </summary>
+    public class NATSReconnectBufferException : NATSConnectionException
+    {
+        internal NATSReconnectBufferException(string err) : base(err) { }
+    }
+
+    /// <summary>
     /// This exception that is thrown when there is an internal error with
     /// the NATS protocol.
     /// </summary>

--- a/src/NATS.Client/IConnection.cs
+++ b/src/NATS.Client/IConnection.cs
@@ -80,6 +80,10 @@ namespace NATS.Client
         /// the current connection.</param>
         /// <param name="data">An array of type <see cref="Byte"/> that contains the data to publish
         /// to the connected NATS server.</param>
+        /// <exception cref="NATSReconnectBufferException"> is thrown when
+        /// publishing while reconnecting and the internal reconnect buffer
+        /// has been disabled or exceeded.</exception>
+        /// <seealso cref="Options.ReconnectBufferSize"></seealso>
         void Publish(string subject, byte[] data);
 
         /// <summary>

--- a/src/NATS.Client/NATS.cs
+++ b/src/NATS.Client/NATS.cs
@@ -137,6 +137,11 @@ namespace NATS.Client
         /// </summary>
         public const int DefaultDrainTimeout = 30000;
 
+        /// <summary>
+        /// Default Pending buffer size is 8 MB.
+        /// </summary>
+        public const int ReconnectBufferSize = 8 * 1024 * 1024; // 8MB
+
         /*
          * Namespace level defaults
          */

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -182,6 +182,7 @@ namespace NATS.Client
 
         // Must be greater than 0.
         internal int subscriptionBatchSize = 64;
+        internal int reconnectBufSize = Defaults.ReconnectBufferSize;
 
         internal string user;
         internal string password;
@@ -208,6 +209,7 @@ namespace NATS.Client
             noRandomize = o.noRandomize;
             noEcho = o.noEcho;
             pedantic = o.pedantic;
+            reconnectBufSize = o.reconnectBufSize;
             useOldRequestStyle = o.useOldRequestStyle;
             pingInterval = o.pingInterval;
             ReconnectedEventHandler = o.ReconnectedEventHandler;
@@ -269,7 +271,7 @@ namespace NATS.Client
         }
 
         /// <summary>
-        /// Gets or sets the array of servers that the NATs client will connect to.
+        /// Gets or sets the array of servers that the NATS client will connect to.
         /// </summary>
         /// <remarks>
         /// The individual URLs may contain username/password information.
@@ -585,6 +587,43 @@ namespace NATS.Client
                 sb.AppendFormat("{0}=null;", name);
         }
 
+        
+        /// <summary>
+        /// Constant used to sets the reconnect buffer size to unbounded.
+        /// </summary>
+        /// <seealso cref="ReconnectBufferSize"/>
+        public static readonly int ReconnectBufferSizeUnbounded = 0;
+
+        /// <summary>
+        /// Constant that disables the reconnect buffer.
+        /// </summary>
+        /// <seealso cref="ReconnectBufferSize"/>
+        public static readonly int ReconnectBufferDisabled = -1;
+
+        /// <summary>
+        /// Gets or sets the buffer size of messages kept while busy reconnecting.
+        /// </summary>
+        /// <remarks>
+        /// When reconnecting, the NATS client will hold published messages that
+        /// will be flushed to the new server upon a successful reconnect.  The default
+        /// is buffer size is 8 MB.  This buffering can be disabled.
+        /// </remarks>
+        /// <seealso cref="ReconnectBufferSizeUnbounded"/>
+        /// <seealso cref="ReconnectBufferDisabled"/>
+        public int ReconnectBufferSize
+        {
+            get { return reconnectBufSize; }
+            set
+            {
+                if (value < -1)
+                {
+                    throw new ArgumentOutOfRangeException("value", "Reconnect buffer size must be greater than or equal to -1");
+                }
+
+                reconnectBufSize = value;
+            }
+        }
+
         /// <summary>
         /// Returns a string representation of the
         /// value of this Options instance.
@@ -609,6 +648,7 @@ namespace NATS.Client
             sb.AppendFormat("Pendantic={0};", Pedantic);
             sb.AppendFormat("UseOldRequestStyle={0}", UseOldRequestStyle);
             sb.AppendFormat("PingInterval={0};", PingInterval);
+            sb.AppendFormat("ReconnectBufferSize={0};", ReconnectBufferSize);
             sb.AppendFormat("ReconnectWait={0};", ReconnectWait);
             sb.AppendFormat("Secure={0};", Secure);
             sb.AppendFormat("User={0};", User);

--- a/src/Tests/IntegrationTests/TestConnection.cs
+++ b/src/Tests/IntegrationTests/TestConnection.cs
@@ -454,8 +454,6 @@ namespace IntegrationTests
         }
 
         /// NOT IMPLEMENTED:
-        /// TestServerSecureConnections
-        /// TestErrOnConnectAndDeadlock
         /// TestErrOnMaxPayloadLimit
     }
 

--- a/src/Tests/IntegrationTests/TestReconnect.cs
+++ b/src/Tests/IntegrationTests/TestReconnect.cs
@@ -554,10 +554,9 @@ namespace IntegrationTests
 
             // PUB foo 25\r\n<...> = 30 so first publish should be OK, 2nd publish
             // should fail.
-            byte[] okPayload = new byte[20];
-            byte[] exceedingPayload = new byte[21];
-            c.Publish("foo", okPayload);
-            Assert.Throws<NATSReconnectBufferException>(() => c.Publish("foo", exceedingPayload));
+            byte[] payload = new byte[18];
+            c.Publish("foo", payload);
+            Assert.Throws<NATSReconnectBufferException>(() => c.Publish("foo", payload));
 
             c.Close();
             c.Dispose();

--- a/src/Tests/IntegrationTests/TestReconnect.cs
+++ b/src/Tests/IntegrationTests/TestReconnect.cs
@@ -554,9 +554,10 @@ namespace IntegrationTests
 
             // PUB foo 25\r\n<...> = 30 so first publish should be OK, 2nd publish
             // should fail.
-            byte[] payload = new byte[18];
-            c.Publish("foo", payload);
-            Assert.Throws<NATSReconnectBufferException>(() => c.Publish("foo", payload));
+            byte[] okPayload = new byte[20];
+            byte[] exceedingPayload = new byte[21];
+            c.Publish("foo", okPayload);
+            Assert.Throws<NATSReconnectBufferException>(() => c.Publish("foo", exceedingPayload));
 
             c.Close();
             c.Dispose();


### PR DESCRIPTION
It was easier to manually reapply changes from PR #284 Also fixes comments in that review. I've opened this PR up as a new PR so that you can compare that I didn't miss anything.

As it replaces #284 it also resolves #251 