### PR TITLE
Resolves #272 by parsing out IpV4 or IpV6

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -24,6 +24,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Security.Authentication;
 using System.Globalization;
 using System.Diagnostics;
+using NATS.Client.Extensions;
 using NATS.Client.Internals;
 
 namespace NATS.Client
@@ -439,7 +440,7 @@ namespace NATS.Client
                         sslStream = null;
                     }
 
-                    client = new TcpClient();
+                    client = createTcpClient(s.url);
                     var task = client.ConnectAsync(s.url.Host, s.url.Port);
                     // avoid raising TaskScheduler.UnobservedTaskException if the timeout occurs first
                     task.ContinueWith(t => GC.KeepAlive(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
@@ -460,6 +461,15 @@ namespace NATS.Client
                     // save off the hostname
                     hostName = s.url.Host;
                 }
+            }
+
+            private static TcpClient createTcpClient(Uri uri)
+            {
+                var interNetworkAddressFamily = uri.GetInterNetworkAddressFamily();
+
+                return interNetworkAddressFamily != null
+                       ? new TcpClient(interNetworkAddressFamily.Value)
+                       : new TcpClient();
             }
 
             private static bool remoteCertificateValidation(

--- a/src/NATS.Client/Extensions/UriExtensions.cs
+++ b/src/NATS.Client/Extensions/UriExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace NATS.Client.Extensions
+{
+    public static class UriExtensions
+    {
+        public static AddressFamily? GetInterNetworkAddressFamily(this Uri uri)
+        {
+            if(uri.HostNameType != UriHostNameType.IPv4 && uri.HostNameType != UriHostNameType.IPv6)
+                return null;
+
+            if (IPAddress.TryParse(uri.Host, out var ipAddress) && ipAddress?.AddressFamily == AddressFamily.InterNetwork || ipAddress?.AddressFamily == AddressFamily.InterNetworkV6)
+                return ipAddress.AddressFamily;
+
+            return null;
+        }
+    }
+}

--- a/src/Tests/IntegrationTests/TestConnection.cs
+++ b/src/Tests/IntegrationTests/TestConnection.cs
@@ -1160,4 +1160,22 @@ namespace IntegrationTests
         }
 #endif
     }
+
+    public class TestIpV6Connection : TestSuite<ConnectionIpV6SuiteContext>
+    {
+        public TestIpV6Connection(ConnectionIpV6SuiteContext context) : base(context) { }
+
+        [Fact]
+        public void CanConnectUsingIpV6()
+        {
+            var opts = Context.GetTestOptions(Context.Server1.Port);
+            opts.Url = $"nats://[::1]:{Context.Server1.Port}";
+
+            using (NATSServer.CreateFastAndVerify(Context.Server1.Port))
+            {
+                using (var cn = Context.ConnectionFactory.CreateConnection(opts))
+                    Assert.True(cn.State == ConnState.CONNECTED, $"Failed to connect. Expected '{ConnState.CONNECTED}' got '{cn.State}'");
+            }
+        }
+    }
 }

--- a/src/Tests/IntegrationTests/TestSuite.cs
+++ b/src/Tests/IntegrationTests/TestSuite.cs
@@ -48,6 +48,7 @@ namespace IntegrationTests
         public const int TlsSuite = 11514; //3pc
         public const int RxSuite = 11517; //1pc
         public const int AsyncAwaitDeadlocksSuite = 11518; //1pc
+        public const int ConnectionIpV6Suite = 11519; //1pc
     }
 
     public abstract class SuiteContext
@@ -92,7 +93,7 @@ namespace IntegrationTests
         public const string CollectionKey = "9733f463316047fa9207e0a3aaa3c41a";
 
         private const int SeedPortNormalServers = TestSeedPorts.DefaultSuiteNormalServers;
-        
+
         public readonly TestServerInfo DefaultServer = new TestServerInfo(Defaults.Port);
 
         public readonly TestServerInfo Server1 = new TestServerInfo(SeedPortNormalServers);
@@ -141,6 +142,13 @@ namespace IntegrationTests
     public class ConnectionDrainSuiteContext : SuiteContext
     {
         private const int SeedPort = TestSeedPorts.ConnectionDrainSuite;
+
+        public readonly TestServerInfo Server1 = new TestServerInfo(SeedPort);
+    }
+
+    public class ConnectionIpV6SuiteContext : SuiteContext
+    {
+        private const int SeedPort = TestSeedPorts.ConnectionIpV6Suite;
 
         public readonly TestServerInfo Server1 = new TestServerInfo(SeedPort);
     }

--- a/src/Tests/UnitTests/Extensions/TestUriExtensions.cs
+++ b/src/Tests/UnitTests/Extensions/TestUriExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Net.Sockets;
+using NATS.Client.Extensions;
+using Xunit;
+
+namespace UnitTests.Extensions
+{
+    public class TestUriExtensions
+    {
+        [Theory]
+        [InlineData("nats://127.0.0.1:4222", AddressFamily.InterNetwork)]
+        [InlineData("nats://[::1]:4222", AddressFamily.InterNetworkV6)]
+        [InlineData("nats://localhost:4222", null)]
+        [InlineData("http://nats.io", null)]
+        [InlineData("c:/temp.txt", null)]
+        public void GetInterNetworkAddressFamily(string address, AddressFamily? expected)
+        {
+            var r = new Uri(address).GetInterNetworkAddressFamily();
+            
+            Assert.Equal(expected, r);
+        }
+    }
+}

--- a/src/Tests/UnitTests/UnitTests.csproj
+++ b/src/Tests/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;net452</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
Explicitly looking for IpV4 and IpV6 otherwise falling back to framework support to not change existing behavior. The goal was to change as little as possible to solve the issue. We could of course to the DNS resolve or add connection option if we want. But that could int that case perhaps be added as a separate PR as that would be more of a "feature".