### PR TITLE
Auth error reconnects

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -1150,7 +1150,7 @@ namespace NATS.Client
 
                 NATSConnectionException natsAuthEx = null;
 
-                for(var i = 0; i < 10; i++) //Precaution to not end up in server returning ExTypeA, ExTypeB, ExTypeA etc.
+                for(var i = 0; i < 6; i++) //Precaution to not end up in server returning ExTypeA, ExTypeB, ExTypeA etc.
                 {
                     try
                     {
@@ -1172,11 +1172,7 @@ namespace NATS.Client
 
                         var aseh = opts.AsyncErrorEventHandler;
                         if (aseh != null)
-                        {
-                            callbackScheduler.Add(
-                                () => { aseh(s, new ErrEventArgs(this, null, ex.Message)); }
-                            );
-                        }
+                            callbackScheduler.Add(() => aseh(s, new ErrEventArgs(this, null, ex.Message)));
 
                         if (natsAuthEx == null || !natsAuthEx.Message.Equals(ex.Message, StringComparison.OrdinalIgnoreCase))
                         {

--- a/src/NATS.Client/Exceptions.cs
+++ b/src/NATS.Client/Exceptions.cs
@@ -35,6 +35,15 @@ namespace NATS.Client
         internal NATSConnectionException(string err, Exception innerEx) : base(err, innerEx) { }
     }
 
+    internal static class NATSConnectionExceptionExtensions
+    {
+        internal static bool IsAuthorizationViolationError(this NATSConnectionException ex)
+            => ex?.Message.Equals("'authorization violation'", StringComparison.OrdinalIgnoreCase) == true;
+        
+        internal static bool IsAuthenticationExpiredError(this NATSConnectionException ex)
+            => ex?.Message.Equals("'authentication expired'", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
     /// <summary>
     /// The exception that is thrown when there is an error writing
     /// to the internal reconnect buffer.

--- a/src/Tests/IntegrationTests/TestAuthorization.cs
+++ b/src/Tests/IntegrationTests/TestAuthorization.cs
@@ -141,13 +141,52 @@ namespace IntegrationTests
 
             using (NATSServer.CreateWithConfig(Context.Server1.Port, "auth.conf"))
             {
-                Assert.Throws<NATSConnectionException>(() =>
+                var ex = Assert.Throws<NATSConnectionException>(() =>
                 {
                     using (var cn = Context.ConnectionFactory.CreateConnection(opts)) { }
                 });
+                Assert.Equal("'Authorization Violation'", ex.Message, StringComparer.OrdinalIgnoreCase);
             }
 
             Assert.True(cbEvent.WaitOne(1000));
+        }
+
+        [Fact]
+        public void TestExpiredJwt()
+        {
+            var expiredUserJwt 
+                = "eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJleHAiOjE1NDg5NzkyMDAs" +
+                  "Imp0aSI6IlhURFdZUVc3QldDNzJSR0RaVzNWMlNGQUxFRklCWlRKRkZLWDRTVEpa" +
+                  "TVZYWFFBSk01WVEiLCJpYXQiOjE1NzM1NDMyNjYsImlzcyI6IkFBNTVENUw1S0sz" +
+                  "WElJNklLSDc0Vk5CUDNTVjNKWUxVQlRKTkxTVEM2NjJKTDZWN0FPWk9GT0NIIiwi" +
+                  "bmFtZSI6IlRlc3RVc2VyIiwibmJmIjoxNTQ2MzAwODAwLCJzdWIiOiJVRDZPVUNS" +
+                  "T1VEQTZBTTdZMjMySTRLTFVGWU40TTNPWUxJWFhVU0FNTzVQT1RVMkpaVjNVNzY3" +
+                  "SiIsInR5cGUiOiJ1c2VyIiwibmF0cyI6eyJwdWIiOnt9LCJzdWIiOnt9fX0.n81V" +
+                  "bNLwtYMRYfUDbLgnn0MzFL3imxlEk0PQSzOxQpB_nBkVKvRUtbnd22iS8S9i_HRO" +
+                  "FJXfk26xEoOhYtCACg";
+
+            var userSeed = "SUAIBDPBAUTWCWBKIO6XHQNINK5FWJW4OHLXC3HQ2KFE4PEJUA44CNHTC4A";
+    
+            using (NATSServer.CreateWithConfig(Context.Server1.Port, "operator.conf"))
+            {
+                EventHandler<UserJWTEventArgs> jwtEh = (sender, args) => args.JWT = expiredUserJwt;
+                EventHandler<UserSignatureEventArgs> sigEh = (sender, args) =>
+                {
+                    // generate a nats key pair from a private key.
+                    // NEVER EVER handle a real private key/seed like this.
+                    var kp = Nkeys.FromSeed(userSeed);
+                    args.SignedNonce = kp.Sign(args.ServerNonce);
+                };
+                var opts = Context.GetTestOptionsWithDefaultTimeout(Context.Server1.Port);
+                opts.SetUserCredentialHandlers(jwtEh, sigEh);
+
+                var ex = Assert.Throws<NATSConnectionException>(() =>
+                {
+                    using(Context.ConnectionFactory.CreateConnection(opts)){ }
+                });
+
+                Assert.Equal("'Authorization Violation'", ex.Message, StringComparer.OrdinalIgnoreCase);
+            }
         }
 
 #if NET452

--- a/src/Tests/IntegrationTests/TestUtilities.cs
+++ b/src/Tests/IntegrationTests/TestUtilities.cs
@@ -132,7 +132,7 @@ namespace IntegrationTests
         private void createProcessStartInfo()
         {
             psInfo = new ProcessStartInfo(SERVEREXE);
-            psInfo.UseShellExecute = false;
+            psInfo.UseShellExecute = Debug || !HideWindow;
 
             if (Debug)
             {


### PR DESCRIPTION
Solves #282 by adding support for retrying connect attempts upon auth failures.

The `Authentication expired` error was taken from documentation, I can not see that happen. As in, not sure how to test it. Tried with an expired JWT but get `Authentication Violation` for that.
@ColinSullivan1  Should it still be in?

Also, `Authentication Timeout` never reaches client as the server cuts the connection, so when we read from the stream, the underlying socket is disconnected. Maybe the server should have a short delay before cutting a client of?

@ColinSullivan1 Are there any other specific auth violations that we should look for?