### PR TITLE
Disables creating package for WinForms sample

### DIFF
--- a/src/Samples/WinFormsSample/WinFormsSample.csproj
+++ b/src/Samples/WinFormsSample/WinFormsSample.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <IsPackable>false</IsPackable>
     <Configurations>Debug;Release;LinuxRelease;LinuxDebug</Configurations>
   </PropertyGroup>
 


### PR DESCRIPTION
This slipped through in the last PR. Creating NuGet packages for samples is nothing we do.