### PR TITLE
Handle zero length reads correctly

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -1776,10 +1776,17 @@ namespace NATS.Client
                 {
                     len = br.Read(buffer, 0, Defaults.defaultReadLength);
 
-                    // Socket has been closed gracefully by host
+                    // A length of zero can mean that the socket was closed
+                    // locally by the appliation (Close) or the server
+                    // gracefully closed the socket.  There are some cases
+                    // on windows where a server could take an exit path that
+                    // gracefully closed sockets.  Throw an exception so we
+                    // can reconnect.  If the network stream has been closed
+                    // by the client, processOpError will do the right thing
+                    // (nothing).
                     if (len == 0)
                     {
-                        break;
+                        throw new NATSConnectionException("Server closed the connection");
                     }
 
                     parser.parse(buffer, len);

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -1777,10 +1777,10 @@ namespace NATS.Client
                     len = br.Read(buffer, 0, Defaults.defaultReadLength);
 
                     // A length of zero can mean that the socket was closed
-                    // locally by the appliation (Close) or the server
+                    // locally by the application (Close) or the server
                     // gracefully closed the socket.  There are some cases
                     // on windows where a server could take an exit path that
-                    // gracefully closed sockets.  Throw an exception so we
+                    // gracefully closes sockets.  Throw an exception so we
                     // can reconnect.  If the network stream has been closed
                     // by the client, processOpError will do the right thing
                     // (nothing).

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -1786,7 +1786,7 @@ namespace NATS.Client
                     // (nothing).
                     if (len == 0)
                     {
-                        throw new NATSConnectionException("Server closed the connection");
+                        throw new NATSConnectionException("Server closed the connection.");
                     }
 
                     parser.parse(buffer, len);


### PR DESCRIPTION
The NATS server had an exit path on windows that would sometimes gracefully close a socket, which can create a zero length read on at NetworkStream.

The client assumed a zero length read would only occur when it closed the socket (not the server), so was keying on that to exit the readLoop.  When the server would gracefully shut sockets down, the client could encounter a zero length read on reconnect, killing the readLoop(), rendering the client unable to process messages.

This fix treats a zero length read as an error, and if we're in the process of reconnecting or closing, the processOpError method will do the right thing.

Many thanks to @danielwertheim for helping debug this problem.

Resolves #326, #315.

Signed-off-by: Colin Sullivan <colin@synadia.com>