### PR TITLE
Splits pipe into two, one for CI and one for CD

### DIFF
--- a/az-templates/stage-build.yml
+++ b/az-templates/stage-build.yml
@@ -1,30 +1,3 @@
-name: $(Semver)
-
-variables:
-  BuildRev: $[counter(format('{0:yyyyMMdd}', pipeline.startTime), 1)]
-  ${{ if startsWith( variables['Build.SourceBranch'], 'refs/tags' ) }}:
-    SemVer: $[ variables['Build.SourceBranchName'] ]
-  ${{ if not( startsWith( variables['Build.SourceBranch'], 'refs/tags' )) }}:
-    SemVer: $[format('{0:yyyy}.{0:MM}.{0:dd}-pre{1}', pipeline.startTime, variables.BuildRev)]
-  InfoVer: $(Build.SourceVersion)
-
-trigger:
-  batch: true
-  branches:
-    include:
-    - master
-    - refs/tags/*
-
-pr:
-  autoCancel: true
-  branches:
-    include:
-    - master
-
-pool:
-  name: Azure Pipelines
-  vmImage: windows-2019
-
 stages:
 - stage: Build
   jobs:
@@ -127,26 +100,3 @@ stages:
       inputs:
         path: '$(Build.ArtifactStagingDirectory)'
         artifact: Artifacts
-
-- stage: Deploy
-  condition: and (succeeded(), startsWith( variables['Build.SourceBranch'], 'refs/tags' ))
-  dependsOn: Build
-  jobs:
-  - deployment: DeployArtifacts
-    environment: 'Prod'
-    displayName: 'Deploys artifacts'
-    timeoutInMinutes: 10
-    cancelTimeoutInMinutes: 5
-    strategy: 
-      runOnce:
-        deploy:
-          steps:
-          - checkout: none
-          - task: NuGetCommand@2
-            displayName: 'Push Nupkg to NuGet.Org'
-            inputs:
-              command: push
-              nugetFeedType: external
-              publishFeedCredentials: nuget_org_push_new_versions
-              verbosityPush: Normal
-              packagesToPush: '$(Pipeline.Workspace)/**/*.nupkg;!$(Pipeline.Workspace)/**/*.symbols.nupkg'

--- a/az-templates/stage-deploy.yml
+++ b/az-templates/stage-deploy.yml
@@ -1,0 +1,22 @@
+- stage: Deploy
+  condition: and (succeeded(), startsWith( variables['Build.SourceBranch'], 'refs/tags' ))
+  dependsOn: Build
+  jobs:
+  - deployment: DeployArtifacts
+    environment: 'Prod'
+    displayName: 'Deploys artifacts'
+    timeoutInMinutes: 10
+    cancelTimeoutInMinutes: 5
+    strategy: 
+      runOnce:
+        deploy:
+          steps:
+          - checkout: none
+          - task: NuGetCommand@2
+            displayName: 'Push Nupkg to NuGet.Org'
+            inputs:
+              command: push
+              nugetFeedType: external
+              publishFeedCredentials: nuget_org_push_new_versions
+              verbosityPush: Normal
+              packagesToPush: '$(Pipeline.Workspace)/**/*.nupkg;!$(Pipeline.Workspace)/**/*.symbols.nupkg'

--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -1,0 +1,22 @@
+name: $(SemVer)
+
+variables:
+  BuildRev: $[counter(format('{0:yyyyMMdd}', pipeline.startTime), 1)]
+  SemVer: $[ variables['Build.SourceBranchName'] ]
+  InfoVer: $(Build.SourceVersion)
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - refs/tags/*
+
+pr: none
+
+pool:
+  name: Azure Pipelines
+  vmImage: windows-2019
+
+stages:
+- template: az-templates/stage-build.yml
+- template: az-templates/stage-deploy.yml

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -1,0 +1,25 @@
+name: $(SemVer)
+
+variables:
+  BuildRev: $[counter(format('{0:yyyyMMdd}', pipeline.startTime), 1)]
+  SemVer: $[format('{0:yyyy}.{0:MM}.{0:dd}-pre{1}', pipeline.startTime, variables.BuildRev)]
+  InfoVer: $(Build.SourceVersion)
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - master
+
+pool:
+  name: Azure Pipelines
+  vmImage: windows-2019
+
+stages:
+- template: az-templates/stage-build.yml


### PR DESCRIPTION
This so that we can simplify for forks and PRs from forks as the CI flow now does not require a NuGet connection. That is only required in the CD flow which is only needed from this repo.

Once this is in, I'll setup one more pipe in AZ for the CD flow.