### PR TITLE
Removes handshakeReadTimeout as it was replaced

### DIFF
--- a/src/NATS.Client/NATS.cs
+++ b/src/NATS.Client/NATS.cs
@@ -160,8 +160,6 @@ namespace NATS.Client
 
         // Default server pool size
         internal const int srvPoolSize = 4;
-
-        internal static readonly int? handshakeReadTimeout = null;
     }
 
     /// <summary>


### PR DESCRIPTION
Was introduced and the never used in PR last week.