### PR TITLE
Request optimizations

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2812,14 +2812,13 @@ namespace NATS.Client
 
         private void requestResponseHandler(object sender, MsgHandlerEventArgs e)
         {
+            if (e.Message == null)
+                return;
+
             //               \
             //               \/
             //  _INBOX.<nuid>.<requestId>
-            string requestId = e.Message.Subject.Substring(globalRequestInbox.Length + 1);
-            if (e.Message == null)
-            {
-                return;
-            }
+            var requestId = e.Message.Subject.Substring(globalRequestInbox.Length + 1);
 
             bool isClosed;
             InFlightRequest request;

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2665,10 +2665,14 @@ namespace NATS.Client
             request.Waiter.Task.ContinueWith(t => GC.KeepAlive(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
             waitingRequests.TryAdd(request.Id, request);
 
+            if (globalRequestSubscription != null)
+                return request;
+
             lock (mu)
             {
-                if(globalRequestSubscription == null)
-                    globalRequestSubscription = subscribeAsync(string.Concat(globalRequestInbox, ".*"), null, requestResponseHandler);
+                if (globalRequestSubscription == null)
+                    globalRequestSubscription = subscribeAsync(string.Concat(globalRequestInbox, ".*"), null,
+                        requestResponseHandler);
             }
 
             return request;
@@ -2691,9 +2695,6 @@ namespace NATS.Client
             using (var request = setupRequest(timeout, CancellationToken.None))
             {
                 request.Token.ThrowIfCancellationRequested();
-
-                if (globalRequestSubscription == null)
-                    throw new NATSException("No global inbox subscription exists for receiving request responses in.");
 
                 publish(subject, string.Concat(globalRequestInbox, ".", request.Id), data, offset, count, true);
 
@@ -2734,9 +2735,6 @@ namespace NATS.Client
             using (var request = setupRequest(timeout, token))
             {
                 request.Token.ThrowIfCancellationRequested();
-
-                if (globalRequestSubscription == null)
-                    throw new NATSException("No global inbox subscription exists for receiving request responses in.");
 
                 publish(subject, string.Concat(globalRequestInbox, ".", request.Id), data, offset, count, true);
 

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -757,9 +757,6 @@ namespace NATS.Client
             return null;
         }
 
-        // Ensure we cannot instanciate a connection this way.
-        private Connection() { }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Connection"/> class
         /// with the specified <see cref="Options"/>.

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -123,8 +123,6 @@ namespace NATS.Client
         private Uri             url     = null;
         private ServerPool srvPool = new ServerPool();
 
-        private Dictionary<string, Uri> urls = new Dictionary<string, Uri>();
-
         // we have a buffered reader for writing, and reading.
         // This is for both performance, and having to work around
         // interlinked read/writes (supported by the underlying network

--- a/src/Samples/WinFormsSample/Form1.cs
+++ b/src/Samples/WinFormsSample/Form1.cs
@@ -77,6 +77,21 @@ namespace WinFormsSample
                 }, cts.Token);
             }));
 
+            lstScenarios.Items.Add(new Scenario("Request (timeout)", () =>
+            {
+                var payload = Encoding.UTF8.GetBytes(Guid.NewGuid().ToString("N"));
+
+                return Task.Run(() =>
+                {
+                    var numOfMessages = NumOfMessages;
+                    for (var i = 0; i < numOfMessages; i++)
+                    {
+                        if (!cts.IsCancellationRequested)
+                            pubConnection.Request(Subject, payload, 150);
+                    }
+                }, cts.Token);
+            }));
+
             lstScenarios.Items.Add(new Scenario("RequestAsync", async () =>
             {
                 var configAwaitFalse = chkConfigureAwaitFalse.Checked;
@@ -86,6 +101,17 @@ namespace WinFormsSample
 
                 for (var i = 0; i < numOfMessages; i++)
                     await pubConnection.RequestAsync(Subject, payload, cts.Token).ConfigureAwait(!configAwaitFalse);
+            }));
+
+            lstScenarios.Items.Add(new Scenario("RequestAsync (timeout)", async () =>
+            {
+                var configAwaitFalse = chkConfigureAwaitFalse.Checked;
+                var payload = Encoding.UTF8.GetBytes(Guid.NewGuid().ToString("N"));
+
+                var numOfMessages = NumOfMessages;
+
+                for (var i = 0; i < numOfMessages; i++)
+                    await pubConnection.RequestAsync(Subject, payload, 150).ConfigureAwait(!configAwaitFalse);
             }));
 
             lstScenarios.Items.Add(new Scenario("RequestAsync (batched)", async () =>

--- a/src/Samples/WinFormsSample/Form1.cs
+++ b/src/Samples/WinFormsSample/Form1.cs
@@ -196,8 +196,6 @@ namespace WinFormsSample
             {
                 await Task.Run(async () =>
                 {
-                    GC.Collect();
-
                     var configAwaitFalse = chkConfigureAwaitFalse.Checked;
                     var requester = scenario.Action();
 

--- a/src/Samples/WinFormsSample/Form1.cs
+++ b/src/Samples/WinFormsSample/Form1.cs
@@ -1,6 +1,4 @@
-﻿
-using System.Collections.Generic;
-#if Windows
+﻿#if Windows
 using System;
 using System.Text;
 using System.Threading;


### PR DESCRIPTION
After these changes when running the Benchmarks included I see an increase with about _20%_ in the request async flow.

When debugging and monitoring GC activity (as discussed in #299), both with and without a specified timeout, I see a highly reduced GC activity also leading to reducing CPU activity.