### PR TITLE
Updates cache value for NuGet shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This NATS Maintainer supported client parallels the [NATS GO Client](https://git
 [![License Apache 2.0](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![API Documentation](https://img.shields.io/badge/doc-Doxygen-brightgreen.svg?style=flat)](http://nats-io.github.io/nats.net)
 [![Build Status](https://dev.azure.com/NATS-CI/NATS-CI/_apis/build/status/nats-io.nats.net-CI?branchName=master)](https://dev.azure.com/NATS-CI/NATS-CI/_build/latest?definitionId=2&branchName=master)
-[![NuGet](https://img.shields.io/nuget/v/NATS.Client.svg?maxAge=2592000)](https://www.nuget.org/packages/NATS.Client)
+[![NuGet](https://img.shields.io/nuget/v/NATS.Client.svg?cacheSeconds=3600)](https://www.nuget.org/packages/NATS.Client)
 
 ## Getting started
 The easiest and recommended way to start using NATS in you .NET projects, is to use the [NuGet package]((https://www.nuget.org/packages/NATS.Client)). For examples on how to use the client, see below or in any of the included sample projects.


### PR DESCRIPTION
`maxAge` is deprecated (still supported) and replaced with `cacheSeconds`

Reducing to 3600s (1h) as 2592000s seem a bit high. Default is 300s