### PR TITLE
Fixes so that conn.unsubscribe does not return null

### DIFF
--- a/src/NATS.Client/Internals/CompletedTask.cs
+++ b/src/NATS.Client/Internals/CompletedTask.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2015-2018 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+
+namespace NATS.Client.Internals
+{
+    internal static class CompletedTask
+    {
+#if NET45
+        private static readonly Task Completed = Task.FromResult(true);
+#endif
+        internal static Task Get() =>
+#if NET45
+            Completed;
+#else
+            Task.CompletedTask;
+#endif
+    }
+}


### PR DESCRIPTION
Extracts CompletedTask and uses a completed task instead of null.