### PR TITLE
Fixes so that bw.Position is not used when NetworkStream

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2496,7 +2496,7 @@ namespace NATS.Client
                         else
                             kickFlusher();
 
-                        if (bw.Position + count + pubProtoLen > rbsize)
+                        if (pending != null && bw.Position + count + pubProtoLen > rbsize)
                             throw new NATSReconnectBufferException("Reconnect buffer exceeded.");
                     }
                 }


### PR DESCRIPTION
Only works when MemoryStream (pending) is used.

Case occurred here: https://github.com/nats-io/stan.net/issues/162

Tried to go through and find why we end up in this situation. Thought it was status access without lock but couldn't find it.