### PR TITLE
Remove ConcurrentDictionary usage

### DIFF
--- a/src/NATS.Client/SyncSub.cs
+++ b/src/NATS.Client/SyncSub.cs
@@ -118,7 +118,7 @@ namespace NATS.Client
                 if (d == localMax)
                 {
                     // Remove subscription if we have reached max.
-                    localConn.removeSub(this);
+                    localConn.removeSubSafe(this);
                 }
                 if (localMax > 0 && d > localMax)
                 {


### PR DESCRIPTION
Given recent issues with Unity, this PR removes use of the ConcurrentDictionary from Connection Subscriptions, removing it entirely.

See #358, #361, and the Unity issue [here](https://issuetracker.unity3d.com/issues/anroid-logcat-throws-advapi32-related-warning-when-using-concurrentdictionary-in-il2cpp-builds).

CC @britvich

Signed-off-by: Colin Sullivan <colin@synadia.com>