### PR TITLE
Fix for Unity IL2CPP builds

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -1704,43 +1704,41 @@ namespace NATS.Client
         {
             // Stack based buffer.
             byte[] buffer = new byte[Defaults.defaultReadLength];
-            using (var parser = new Parser(this))
+			var parser = new Parser(this);
+            int len;
+
+            while (true)
             {
-                int len;
-
-                while (true)
+                try
                 {
-                    try
+                    len = br.Read(buffer, 0, Defaults.defaultReadLength);
+
+                    // A length of zero can mean that the socket was closed
+                    // locally by the application (Close) or the server
+                    // gracefully closed the socket.  There are some cases
+                    // on windows where a server could take an exit path that
+                    // gracefully closes sockets.  Throw an exception so we
+                    // can reconnect.  If the network stream has been closed
+                    // by the client, processOpError will do the right thing
+                    // (nothing).
+                    if (len == 0)
                     {
-                        len = br.Read(buffer, 0, Defaults.defaultReadLength);
+                        if (disposedValue || State == ConnState.CLOSED)
+                            break;
 
-                        // A length of zero can mean that the socket was closed
-                        // locally by the application (Close) or the server
-                        // gracefully closed the socket.  There are some cases
-                        // on windows where a server could take an exit path that
-                        // gracefully closes sockets.  Throw an exception so we
-                        // can reconnect.  If the network stream has been closed
-                        // by the client, processOpError will do the right thing
-                        // (nothing).
-                        if (len == 0)
-                        {
-                            if (disposedValue || State == ConnState.CLOSED)
-                                break;
-
-                            throw new NATSConnectionException("Server closed the connection.");
-                        }
-
-                        parser.parse(buffer, len);
+                        throw new NATSConnectionException("Server closed the connection.");
                     }
-                    catch (Exception e)
+
+                    parser.parse(buffer, len);
+                }
+                catch (Exception e)
+                {
+                    if (State != ConnState.CLOSED)
                     {
-                        if (State != ConnState.CLOSED)
-                        {
-                            processOpError(e);
-                        }
-
-                        break;
+                        processOpError(e);
                     }
+
+                    break;
                 }
             }
         }
@@ -2655,7 +2653,6 @@ namespace NATS.Client
             {
                 request.Waiter.SetCanceled();
             }
-            request.Dispose();
         }
 
         private InFlightRequest setupRequest(int timeout, CancellationToken token)

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -1704,7 +1704,7 @@ namespace NATS.Client
         {
             // Stack based buffer.
             byte[] buffer = new byte[Defaults.defaultReadLength];
-			var parser = new Parser(this);
+            var parser = new Parser(this);
             int len;
 
             while (true)
@@ -2653,6 +2653,7 @@ namespace NATS.Client
             {
                 request.Waiter.SetCanceled();
             }
+            request.Dispose();
         }
 
         private InFlightRequest setupRequest(int timeout, CancellationToken token)

--- a/src/NATS.Client/Parser.cs
+++ b/src/NATS.Client/Parser.cs
@@ -24,7 +24,7 @@ namespace NATS.Client
 	    internal int    size;
     }
 
-    internal sealed class Parser : IDisposable
+    internal sealed class Parser
     {
         readonly Connection conn;
         readonly byte[] argBufBase = new byte[Defaults.defaultBufSize];
@@ -527,10 +527,5 @@ namespace NATS.Client
      
         } // parse
 
-        public void Dispose()
-        {
-            argBufStream.Dispose();
-            msgBufStream.Dispose();
-        }
     }
 }


### PR DESCRIPTION
This fixes Unity IL2CPP builds that use nats.net. #361 #358

For some unknown reason, Unity IL2CPP builds call `Dispose` on `Parser` each time a message is parsed. It appears Unity is not generating the proper code for the statement:

```c#
using (var parser = new Parser(this))
```

...in `conn.cs:1707`. This causes the parser to fail the second time it parses a reply (on line 205):

```c#
argBufStream.WriteByte((byte)b);
```

...since `argBufStream` is disposed after parsing the first reply. To prevent this from happening, the `IDisposable` and `Dispose` in `Parser.cs` have been removed, as they aren't needed anyway. Also, the `using` part of the statement above has been removed.