### PR TITLE
Add ClientIP Connection property

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -26,6 +26,7 @@ using System.Globalization;
 using System.Diagnostics;
 using NATS.Client.Extensions;
 using NATS.Client.Internals;
+using System.Net;
 
 namespace NATS.Client
 {
@@ -983,6 +984,27 @@ namespace NATS.Client
                         return null;
 
                     return url.OriginalString;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the IP of client as known by the NATS server, otherwise <c>null</c>.
+        /// </summary>
+        /// <remarks>
+        /// Supported in the NATS server version 2.1.6 and above.  If the client is connected to
+        /// an older server or is in the process of connecting, null will be returned.
+        /// </remarks>
+        public IPAddress ClientIP
+        {
+            get
+            {
+                lock (mu)
+                {
+                    if (string.IsNullOrEmpty(info.client_ip))
+                        return null;
+
+                    return IPAddress.Parse(info.client_ip);
                 }
             }
         }

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -999,13 +999,13 @@ namespace NATS.Client
         {
             get
             {
+                string clientIp;
                 lock (mu)
                 {
-                    if (string.IsNullOrEmpty(info.client_ip))
-                        return null;
-
-                    return IPAddress.Parse(info.client_ip);
+                    clientIp = info.client_ip;
                 }
+                
+                return !String.IsNullOrEmpty(clientIp) ? IPAddress.Parse(clientIp) : null;
             }
         }
 

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net;
 using System.Net.Sockets;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -26,7 +27,6 @@ using System.Globalization;
 using System.Diagnostics;
 using NATS.Client.Extensions;
 using NATS.Client.Internals;
-using System.Net;
 
 namespace NATS.Client
 {

--- a/src/NATS.Client/IConnection.cs
+++ b/src/NATS.Client/IConnection.cs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -26,6 +27,15 @@ namespace NATS.Client
         /// Gets the configuration options for this instance.
         /// </summary>
         Options Opts { get; }
+
+        /// <summary>
+        /// Gets the IP of client as known by the NATS server, otherwise <c>null</c>.
+        /// </summary>
+        /// <remarks>
+        /// Supported in the NATS server version 2.1.6 and above.  If the client is connected to
+        /// an older server or is in the process of connecting, null will be returned.
+        /// </remarks>
+        IPAddress ClientIP { get; }
 
         /// <summary>
         /// Gets the URL of the NATS server to which this instance

--- a/src/NATS.Client/Info.cs
+++ b/src/NATS.Client/Info.cs
@@ -21,6 +21,8 @@ namespace NATS.Client
     {
         public string server_id { get; private set; }
 
+        public string client_ip { get; private set; }
+
         public string host { get; private set; }
 
         public int port { get; private set; }
@@ -46,6 +48,7 @@ namespace NATS.Client
             return new ServerInfo
             {
                 server_id = x["server_id"].Value,
+                client_ip = x["client_ip"].Value,
                 host = x["host"].Value,
                 port = x["port"].AsInt,
                 version = x["version"].Value,

--- a/src/Tests/IntegrationTests/TestConnection.cs
+++ b/src/Tests/IntegrationTests/TestConnection.cs
@@ -116,14 +116,14 @@ namespace IntegrationTests
             opts.AllowReconnect = false;
             opts.ClosedEventHandler = (sender, args) =>
             {
-                if(args.Error != null)
+                if (args.Error != null)
                     errors.Enqueue(args.Error);
 
                 closedEv.Set();
             };
             opts.DisconnectedEventHandler = (sender, args) =>
             {
-                if(args.Error != null)
+                if (args.Error != null)
                     errors.Enqueue(args.Error);
 
                 disconEv.Set();
@@ -154,21 +154,21 @@ namespace IntegrationTests
             opts.MaxReconnect = 1;
             opts.ClosedEventHandler = (sender, args) =>
             {
-                if(args.Error != null)
+                if (args.Error != null)
                     errors.Enqueue(args.Error);
 
                 closedEv.Set();
             };
             opts.DisconnectedEventHandler = (sender, args) =>
             {
-                if(args.Error != null)
+                if (args.Error != null)
                     errors.Enqueue(args.Error);
 
                 disconEv.Set();
             };
             opts.ReconnectedEventHandler = (sender, args) =>
             {
-                if(args.Error != null)
+                if (args.Error != null)
                     errors.Enqueue(args.Error);
 
                 reconEv.Set();
@@ -220,7 +220,7 @@ namespace IntegrationTests
             {
                 using (var c = Context.OpenConnection(Context.Server1.Port))
                 {
-                    using(var s = c.SubscribeSync("foo"))
+                    using (var s = c.SubscribeSync("foo"))
                     {
                         c.Close();
 
@@ -260,7 +260,7 @@ namespace IntegrationTests
                 var o = Context.GetTestOptions(Context.Server1.Port);
                 o.Verbose = true;
 
-                using(var c = Context.ConnectionFactory.CreateConnection(o))
+                using (var c = Context.ConnectionFactory.CreateConnection(o))
                     c.Close();
             }
         }
@@ -279,7 +279,7 @@ namespace IntegrationTests
                     serverDiscoveredCalled = true;
                 };
 
-                using(var c = Context.ConnectionFactory.CreateConnection(o))
+                using (var c = Context.ConnectionFactory.CreateConnection(o))
                     c.Close();
 
                 Assert.False(serverDiscoveredCalled);
@@ -303,12 +303,12 @@ namespace IntegrationTests
             long ctime = orig;
 
             AutoResetEvent reconnected = new AutoResetEvent(false);
-            AutoResetEvent closed      = new AutoResetEvent(false);
-            AutoResetEvent asyncErr1   = new AutoResetEvent(false);
-            AutoResetEvent asyncErr2   = new AutoResetEvent(false);
-            AutoResetEvent recvCh      = new AutoResetEvent(false);
-            AutoResetEvent recvCh1     = new AutoResetEvent(false);
-            AutoResetEvent recvCh2     = new AutoResetEvent(false);
+            AutoResetEvent closed = new AutoResetEvent(false);
+            AutoResetEvent asyncErr1 = new AutoResetEvent(false);
+            AutoResetEvent asyncErr2 = new AutoResetEvent(false);
+            AutoResetEvent recvCh = new AutoResetEvent(false);
+            AutoResetEvent recvCh1 = new AutoResetEvent(false);
+            AutoResetEvent recvCh2 = new AutoResetEvent(false);
 
             using (NATSServer
                    serverAuth = NATSServer.CreateWithConfig(Context.Server1.Port, "auth.conf"),
@@ -360,7 +360,7 @@ namespace IntegrationTests
 
                 o.ReconnectWait = 500;
                 o.NoRandomize = true;
-                o.Servers = new [] { Context.Server2.Url, Context.Server1.Url };
+                o.Servers = new[] { Context.Server2.Url, Context.Server1.Url };
                 o.SubChannelLength = 1;
 
                 using (IConnection
@@ -450,7 +450,7 @@ namespace IntegrationTests
                 }
             }
         }
-        
+
         [Fact]
         public void TestConnectionCloseAndDispose()
         {
@@ -506,7 +506,7 @@ namespace IntegrationTests
         {
             var reconnectEv = new AutoResetEvent(false);
             var closedEv = new AutoResetEvent(false);
-            
+
             var opts = Context.GetTestOptionsWithDefaultTimeout(Context.Server1.Port);
 
             opts.Timeout = 500;
@@ -571,8 +571,17 @@ namespace IntegrationTests
             }
         }
 
-        /// NOT IMPLEMENTED:
-        /// TestErrOnMaxPayloadLimit
+        [Fact]
+        public void TestClientIP()
+        {
+            IConnection conn;
+            using (NATSServer.CreateFastAndVerify(Context.Server1.Port))
+            {
+                conn = Context.ConnectionFactory.CreateConnection("nats://127.0.0.1:" + Context.Server1.Port);
+                Assert.Equal(conn.ClientIP.MapToIPv4(), System.Net.IPAddress.Parse("127.0.0.1"));
+                conn.Close();
+            }
+        }
     }
 
     public class TestConnectionSecurity : TestSuite<ConnectionSecuritySuiteContext>
@@ -778,12 +787,6 @@ namespace IntegrationTests
                 opts.Password = "bar";
                 Assert.Throws<NATSConnectionException>(() => Context.ConnectionFactory.CreateConnection(opts));
             }
-        }
-
-        [Fact(Skip = "WorkInProgress")]
-        public void TestJwtFunctionality()
-        {
-            //using (NATSServer.CreateFastAndVerify(Context.Server1.Port)) { }
         }
     }
 

--- a/src/Tests/IntegrationTests/TestConnection.cs
+++ b/src/Tests/IntegrationTests/TestConnection.cs
@@ -572,6 +572,7 @@ namespace IntegrationTests
         }
 
         [Fact]
+        [Trait("Category", "NATS 2.1.6+")]
         public void TestClientIP()
         {
             IConnection conn;


### PR DESCRIPTION
Add the ClientIP connection property to retrieve the server info client IP field.

Signed-off-by: Colin Sullivan <colin@synadia.com>