### PR TITLE
Set default flush timeout to 10s

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -177,7 +177,7 @@ namespace NATS.Client
         static readonly int REQ_CANCEL_IVL = 100;
 
         // 60 second default flush timeout
-        static readonly int DEFAULT_FLUSH_TIMEOUT = 60000;
+        static readonly int DEFAULT_FLUSH_TIMEOUT = 10000;
 
         TCPConnection conn = new TCPConnection();
 


### PR DESCRIPTION
Set the default flush timeout to 10s for parity with the Golang client.

See:  https://github.com/nats-io/nats.go/pull/561

Signed-off-by: Colin Sullivan <colin@synadia.com>