### PR TITLE
Increase internal buffer sizes

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -737,7 +737,7 @@ namespace NATS.Client
             CRLF_BYTES_LEN = CRLF_BYTES.Length;
 
             // predefine the start of the publish protocol message.
-            buildPublishProtocolBuffer(Defaults.MaxControlLineSize);
+            buildPublishProtocolBuffer(512);
 
             callbackScheduler.Start();
 
@@ -1381,6 +1381,7 @@ namespace NATS.Client
             StreamReader sr = null;
             try
             {
+                // TODO:  Make this reader (or future equivalent) unbounded.
                 // we need the underlying stream, so leave it open.
                 sr = new StreamReader(br, Encoding.UTF8, false, Defaults.MaxControlLineSize, true);
                 result = sr.ReadLine();
@@ -1813,24 +1814,6 @@ namespace NATS.Client
         // Roll our own fast conversion - we know it's the right
         // encoding. 
         char[] convertToStrBuf = new char[Defaults.MaxControlLineSize];
-
-        // Caller must ensure thread safety.
-        private string convertToString(byte[] buffer, long length)
-        {
-            // expand if necessary
-            if (length > convertToStrBuf.Length)
-            {
-                convertToStrBuf = new char[length];
-            }
-
-            for (int i = 0; i < length; i++)
-            {
-                convertToStrBuf[i] = (char)buffer[i];
-            }
-
-            // This is the copy operation for msg arg strings.
-            return new string(convertToStrBuf, 0, (int)length);
-        }
 
         // Since we know we don't need to decode the protocol string,
         // just copy the chars into bytes.  This increased

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -737,7 +737,7 @@ namespace NATS.Client
             CRLF_BYTES_LEN = CRLF_BYTES.Length;
 
             // predefine the start of the publish protocol message.
-            buildPublishProtocolBuffer(Defaults.scratchSize);
+            buildPublishProtocolBuffer(Defaults.MaxControlLineSize);
 
             callbackScheduler.Start();
 
@@ -1382,7 +1382,7 @@ namespace NATS.Client
             try
             {
                 // we need the underlying stream, so leave it open.
-                sr = new StreamReader(br, Encoding.UTF8, false, 512, true);
+                sr = new StreamReader(br, Encoding.UTF8, false, Defaults.MaxControlLineSize, true);
                 result = sr.ReadLine();
 
                 // If opts.verbose is set, handle +OK.
@@ -1432,7 +1432,7 @@ namespace NATS.Client
             // the string directly using the buffered reader.
             //
             // Keep the underlying stream open.
-            using (StreamReader sr = new StreamReader(br, Encoding.ASCII, false, 1024, true))
+            using (StreamReader sr = new StreamReader(br, Encoding.ASCII, false, Defaults.MaxControlLineSize, true))
             {
                 return new Control(sr.ReadLine());
             }
@@ -1812,7 +1812,7 @@ namespace NATS.Client
 
         // Roll our own fast conversion - we know it's the right
         // encoding. 
-        char[] convertToStrBuf = new char[Defaults.scratchSize];
+        char[] convertToStrBuf = new char[Defaults.MaxControlLineSize];
 
         // Caller must ensure thread safety.
         private string convertToString(byte[] buffer, long length)

--- a/src/NATS.Client/NATS.cs
+++ b/src/NATS.Client/NATS.cs
@@ -147,7 +147,7 @@ namespace NATS.Client
          */
 
         // Scratch storage for assembling protocol headers
-        internal const int scratchSize = 512;
+        internal const int MaxControlLineSize = 4096;
 
         // The size of the bufio writer on top of the socket.
         internal const int defaultBufSize = 32768;

--- a/src/NATS.Client/Parser.cs
+++ b/src/NATS.Client/Parser.cs
@@ -43,8 +43,6 @@ namespace NATS.Client
 
         internal int state = 0;
 
-        private const int MAX_CONTROL_LINE_SIZE = 1024;
-
         // For performance declare these as consts - they'll be
         // baked into the IL code (thus faster).  An enum would
         // be nice, but we want speed in this critical section of


### PR DESCRIPTION
The client was having trouble connecting to servers returning large info JSON payloads at connect time.  Unfortunately, this issue was surfacing as a TLS error, so took awhile to track down.

Resolves #377 

Signed-off-by: Colin Sullivan <colin@synadia.com>