### PR TITLE
Avoid publish race

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -1465,6 +1465,12 @@ namespace NATS.Client
                     conn.teardown();
                 }
 
+                // clear any queued pongs, e..g. pending flush calls.
+                clearPendingFlushCalls();
+
+                pending = new MemoryStream();
+                bw = new BufferedStream(pending);
+
                 Thread t = new Thread(() =>
                 {
                     doReconnect();
@@ -1548,13 +1554,6 @@ namespace NATS.Client
             try
             {
                 Monitor.Enter(mu, ref lockWasTaken);
-
-                // clear any queued pongs, e..g. pending flush calls.
-                clearPendingFlushCalls();
-
-                pending = new MemoryStream();
-
-                bw = new BufferedStream(pending);
 
                 //Keep ref to any error before clearing.
                 var errorForHandler = lastEx;


### PR DESCRIPTION
Avoid a (very rare) race condition when publishing during a reconnect where the buffer writer still has the networks stream wrapped instead of the memory stream.

I published several billion messages in testing and couldn't recreate this, although logically it's there.  Many thanks to @jasper-d for the help, and identifying the problem.

Resolves #381  

/CC @kozlovic 

Signed-off-by: Colin Sullivan <colin@synadia.com>