### PR TITLE
Remove NoRandomize usage from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,6 @@ The NATS .NET client supports the cluster discovery protocol.  The list of serve
             Options opts = ConnectionFactory.GetDefaultOptions();
             opts.MaxReconnect = 2;
             opts.ReconnectWait = 1000;
-            opts.NoRandomize = true;
             opts.Servers = servers;
 
             IConnection c = new ConnectionFactory().CreateConnection(opts);


### PR DESCRIPTION
Remove NoRandomize usage from the clustered NATS example. My understanding is that randomization should be enabled in general (c.f. https://docs.nats.io/developing-with-nats/reconnect/random). Disabling it in the sample has caused some confusion with regards to the recommended settings.