### PR TITLE
Fix sync/async deadlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # NATS - .NET C# Client
 
-A [C# .NET](https://msdn.microsoft.com/en-us/vstudio/aa496123.aspx) client for the [NATS messaging system](https://nats.io) multi targetting `.NET4.5+` and `.NETStandard1.6`.
+A [C# .NET](https://msdn.microsoft.com/en-us/vstudio/aa496123.aspx) client for the [NATS messaging system](https://nats.io) multi targetting `.NET4.6+` and `.NETStandard1.6`.
 
 This NATS Maintainer supported client parallels the [NATS GO Client](https://github.com/nats-io/nats).
 
@@ -40,7 +40,7 @@ The repository contains several projects, all located under `src\`
 All examples provide statistics for benchmarking.
 
 ### .NET Core SDK
-.NET Core SDK style projects are used, so ensure your environment (command line, VSCode, Visual Studio, etc) supports the targetted .NET Core SDK in `src\global.json` as well as .NET Framework 4.5.1 or greater.
+.NET Core SDK style projects are used, so ensure your environment (command line, VSCode, Visual Studio, etc) supports the targetted .NET Core SDK in `src\global.json` as well as .NET Framework 4.6 or greater.
 
 ### Visual Studio
 The recommendation is to load `src\NATS.sln` into Visual Studio 2019 (Visual Studio 2017 works as well). .NET Core SDK style projects are used to multitarget different frameworks, so when working with the source code (debugging, running tets etc) you might need to mind the "context" of the current framework.
@@ -230,7 +230,7 @@ namespace RxSample
 The .NET NATS client mirrors go encoding through serialization and
 deserialization.  Simply create an encoded connection and publish
 objects, and receive objects through an asynchronous subscription using
-the encoded message event handler.  The .NET 4.5 client has a default formatter
+the encoded message event handler.  The .NET 4.6 client has a default formatter
 serializing objects using the BinaryFormatter, but methods used to serialize and deserialize
 objects can be overridden.  The NATS core version does not have serialization
 defaults and they must be specified.
@@ -265,7 +265,7 @@ defaults and they must be specified.
 ### Other Types of Serialization
 Optionally, one can override serialization.  Depending on the level of support or
 third party packages used, objects can be serialized to JSON, SOAP, or a custom
-scheme.  XML was chosen as the example here as it is natively supported by .NET 4.5.
+scheme.  XML was chosen as the example here as it is natively supported by .NET 4.6.
 
 ```C#
         // Example XML serialization.

--- a/az-templates/stage-build.yml
+++ b/az-templates/stage-build.yml
@@ -22,12 +22,12 @@ stages:
         testRunTitle: 'UnitTests .NetCoreApp3.1'
   
     - task: VSTest@2
-      displayName: 'UnitTests .Net4.5.2'
+      displayName: 'UnitTests .Net4.6'
       inputs:
         testSelector: 'testAssemblies'
         testAssemblyVer2: 'src/Tests/UnitTests/bin/$(BuildConfiguration)/net452/UnitTests.dll'
         configuration: $(BuildConfiguration)
-        testRunTitle: 'UnitTests .Net4.5.2'
+        testRunTitle: 'UnitTests .Net4.6'
   
     - task: PowerShell@2
       displayName: 'Download latest Win64 NATS-Server'
@@ -74,14 +74,14 @@ stages:
         testRunTitle: 'IntegrationTests .NetCoreApp3.1'
   
     - task: VSTest@2
-      displayName: 'IntegrationTests .Net4.5.2'
+      displayName: 'IntegrationTests .Net4.6'
       inputs:
         testSelector: 'testAssemblies'
         testAssemblyVer2: 'src/Tests/IntegrationTests/bin/$(BuildConfiguration)/net452/IntegrationTests.dll'
         configuration: $(BuildConfiguration)
         rerunFailedTests: True
         rerunMaxAttempts: 2
-        testRunTitle: 'IntegrationTests .Net4.5.2'
+        testRunTitle: 'IntegrationTests .Net4.6'
   
     - task: DotNetCoreCLI@2
       displayName: 'Pack Nupkg'

--- a/az-templates/stage-build.yml
+++ b/az-templates/stage-build.yml
@@ -25,7 +25,7 @@ stages:
       displayName: 'UnitTests .Net4.6'
       inputs:
         testSelector: 'testAssemblies'
-        testAssemblyVer2: 'src/Tests/UnitTests/bin/$(BuildConfiguration)/net452/UnitTests.dll'
+        testAssemblyVer2: 'src/Tests/UnitTests/bin/$(BuildConfiguration)/net46/UnitTests.dll'
         configuration: $(BuildConfiguration)
         testRunTitle: 'UnitTests .Net4.6'
   
@@ -77,7 +77,7 @@ stages:
       displayName: 'IntegrationTests .Net4.6'
       inputs:
         testSelector: 'testAssemblies'
-        testAssemblyVer2: 'src/Tests/IntegrationTests/bin/$(BuildConfiguration)/net452/IntegrationTests.dll'
+        testAssemblyVer2: 'src/Tests/IntegrationTests/bin/$(BuildConfiguration)/net46/IntegrationTests.dll'
         configuration: $(BuildConfiguration)
         rerunFailedTests: True
         rerunMaxAttempts: 2

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netcoreapp3.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netcoreapp3.1;net46</TargetFrameworks>
     <TargetFramework Condition="$(OS) != 'Windows_NT'">netcoreapp3.1</TargetFramework>
     <Version>0.0.0</Version>
     <Company>CNCF</Company>

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -278,7 +278,7 @@ namespace NATS.Client
             {
                 if (!disposedValue)
                 {
-#if NET45
+#if NET46
                     if (executorTask != null)
                         executorTask.Dispose();
 #endif
@@ -421,7 +421,7 @@ namespace NATS.Client
 
             internal static void close(TcpClient c)
             {
-#if NET45
+#if NET46
                     c?.Close();
 #else
                     c?.Dispose();
@@ -636,7 +636,7 @@ namespace NATS.Client
                     // See Connection.deliverMsgs
                     Channel.close();
                     channelTask.Wait(500);
-#if NET45
+#if NET46
                     channelTask.Dispose();
 #endif
                     channelTask = null;
@@ -1495,7 +1495,7 @@ namespace NATS.Client
 
             if (pending.Length > 0)
             {
-#if NET45
+#if NET46
                 bw.Write(pending.GetBuffer(), 0, (int)pending.Length);
                 bw.Flush();
 #else

--- a/src/NATS.Client/EncodedConn.cs
+++ b/src/NATS.Client/EncodedConn.cs
@@ -14,7 +14,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-#if NET45
+#if NET46
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
@@ -110,7 +110,7 @@ namespace NATS.Client
             onDeserialize = defaultDeserializer;
         }
 
-#if NET45
+#if NET46
         private IFormatter f = new BinaryFormatter();
 
         // Note, the connection locks around this, so while we are using a

--- a/src/NATS.Client/Internals/CompletedTask.cs
+++ b/src/NATS.Client/Internals/CompletedTask.cs
@@ -17,11 +17,11 @@ namespace NATS.Client.Internals
 {
     internal static class CompletedTask
     {
-#if NET45
+#if NET46
         private static readonly Task Completed = Task.FromResult(true);
 #endif
         internal static Task Get() =>
-#if NET45
+#if NET46
             Completed;
 #else
             Task.CompletedTask;

--- a/src/NATS.Client/Internals/InFlightRequest.cs
+++ b/src/NATS.Client/Internals/InFlightRequest.cs
@@ -30,10 +30,18 @@ namespace NATS.Client.Internals
         private readonly CancellationTokenSource _tokenSource;
         private readonly CancellationTokenRegistration _tokenRegistration;
         private readonly CancellationToken _clientProvidedToken;
+#if NET45
+        // We use TaskCreationOptions.RunContinuationsAsynchronously to avoid execution of continuations on the thread
+        // that executed TrySetResult/Canceled/Exception. On .NET 45 we use Task.Run() when setting _waiter's result
+        // as a workaround.
+        private readonly TaskCompletionSource<Msg> _waiter = new TaskCompletionSource<Msg>();
+#else
+        private readonly TaskCompletionSource<Msg> _waiter = new TaskCompletionSource<Msg>(TaskCreationOptions.RunContinuationsAsynchronously);
+#endif
 
         public readonly string Id;
         public readonly CancellationToken Token;
-        public readonly TaskCompletionSource<Msg> Waiter = new TaskCompletionSource<Msg>();
+        public readonly Task<Msg> Task;
 
         /// <summary>
         /// Initializes a new instance of <see cref="InFlightRequest"/> class.
@@ -49,6 +57,7 @@ namespace NATS.Client.Internals
             _onCompleted = onCompleted ?? throw new ArgumentNullException(nameof(onCompleted));
             _clientProvidedToken = token;
             Id = id;
+            Task = _waiter.Task;
 
             if (timeout > 0 && token == default)
             {
@@ -76,9 +85,47 @@ namespace NATS.Client.Internals
             var request = req as InFlightRequest;
 
             if (request._clientProvidedToken.IsCancellationRequested)
-                request.Waiter.TrySetCanceled();
+                request._waiter.TrySetCanceled();
 
-            request.Waiter.TrySetException(new NATSTimeoutException());
+            request._waiter.TrySetException(new NATSTimeoutException());
+        }
+
+        /// <summary>
+        /// Attempts to set the result on the underlying <see cref="TaskCompletionSource{TResult}"/>.
+        /// </summary>
+        /// <param name="msg">The received message</param>
+        internal void TrySetResult(Msg msg)
+        {
+#if NET45
+            var _ = System.Threading.Tasks.Task.Run(() => _waiter.TrySetResult(msg));
+#else
+            _waiter.TrySetResult(msg);
+#endif
+        }
+        
+        /// <summary>
+        /// Attempts to set an exception on the underlying <see cref="TaskCompletionSource{TResult}"/>.
+        /// </summary>
+        /// <param name="ex">The exception</param>
+        internal void TrySetException(Exception ex)
+        {
+#if NET45
+            var _ = System.Threading.Tasks.Task.Run(() => _waiter.TrySetException(ex));
+#else
+            _waiter.TrySetException(ex);
+#endif
+        }
+
+        /// <summary>
+        /// Attempts to set the underlying <see cref="TaskCompletionSource{TResult}"/> as canceled.
+        /// </summary>
+        internal void TrySetCanceled()
+        {
+#if NET45
+            var _ = System.Threading.Tasks.Task.Run(() => _waiter.TrySetCanceled());
+#else
+            _waiter.TrySetCanceled();
+#endif
         }
 
         /// <summary>

--- a/src/NATS.Client/Internals/InFlightRequest.cs
+++ b/src/NATS.Client/Internals/InFlightRequest.cs
@@ -30,18 +30,11 @@ namespace NATS.Client.Internals
         private readonly CancellationTokenSource _tokenSource;
         private readonly CancellationTokenRegistration _tokenRegistration;
         private readonly CancellationToken _clientProvidedToken;
-#if NET45
-        // We use TaskCreationOptions.RunContinuationsAsynchronously to avoid execution of continuations on the thread
-        // that executed TrySetResult/Canceled/Exception. On .NET 45 we use Task.Run() when setting _waiter's result
-        // as a workaround.
-        private readonly TaskCompletionSource<Msg> _waiter = new TaskCompletionSource<Msg>();
-#else
-        private readonly TaskCompletionSource<Msg> _waiter = new TaskCompletionSource<Msg>(TaskCreationOptions.RunContinuationsAsynchronously);
-#endif
+
+        internal readonly TaskCompletionSource<Msg> Waiter = new TaskCompletionSource<Msg>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public readonly string Id;
         public readonly CancellationToken Token;
-        public readonly Task<Msg> Task;
 
         /// <summary>
         /// Initializes a new instance of <see cref="InFlightRequest"/> class.
@@ -57,7 +50,6 @@ namespace NATS.Client.Internals
             _onCompleted = onCompleted ?? throw new ArgumentNullException(nameof(onCompleted));
             _clientProvidedToken = token;
             Id = id;
-            Task = _waiter.Task;
 
             if (timeout > 0 && token == default)
             {
@@ -85,47 +77,9 @@ namespace NATS.Client.Internals
             var request = req as InFlightRequest;
 
             if (request._clientProvidedToken.IsCancellationRequested)
-                request._waiter.TrySetCanceled();
+                request.Waiter.TrySetCanceled();
 
-            request._waiter.TrySetException(new NATSTimeoutException());
-        }
-
-        /// <summary>
-        /// Attempts to set the result on the underlying <see cref="TaskCompletionSource{TResult}"/>.
-        /// </summary>
-        /// <param name="msg">The received message</param>
-        internal void TrySetResult(Msg msg)
-        {
-#if NET45
-            var _ = System.Threading.Tasks.Task.Run(() => _waiter.TrySetResult(msg));
-#else
-            _waiter.TrySetResult(msg);
-#endif
-        }
-        
-        /// <summary>
-        /// Attempts to set an exception on the underlying <see cref="TaskCompletionSource{TResult}"/>.
-        /// </summary>
-        /// <param name="ex">The exception</param>
-        internal void TrySetException(Exception ex)
-        {
-#if NET45
-            var _ = System.Threading.Tasks.Task.Run(() => _waiter.TrySetException(ex));
-#else
-            _waiter.TrySetException(ex);
-#endif
-        }
-
-        /// <summary>
-        /// Attempts to set the underlying <see cref="TaskCompletionSource{TResult}"/> as canceled.
-        /// </summary>
-        internal void TrySetCanceled()
-        {
-#if NET45
-            var _ = System.Threading.Tasks.Task.Run(() => _waiter.TrySetCanceled());
-#else
-            _waiter.TrySetCanceled();
-#endif
+            request.Waiter.TrySetException(new NATSTimeoutException());
         }
 
         /// <summary>

--- a/src/NATS.Client/NATS.Client.csproj
+++ b/src/NATS.Client/NATS.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netstandard1.6;net45</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netstandard1.6;net46</TargetFrameworks>
     <TargetFramework Condition="$(OS) != 'Windows_NT'">netstandard1.6</TargetFramework>
     <Title>NATS .NET Client</Title>
     <Description>NATS acts as a central nervous system for distributed systems at scale for IoT, edge computing, and cloud native and on-premise applications.  This is the .NET client API.</Description>

--- a/src/NATS.Client/NUID.cs
+++ b/src/NATS.Client/NUID.cs
@@ -53,7 +53,7 @@ namespace NATS.Client
         private static int  minInc = 33;
         private static int  maxInc = 333;
         private static long totalLen = preLen + seqLen;
-#if NET45
+#if NET46
         private RNGCryptoServiceProvider srand = new RNGCryptoServiceProvider();
 #else
         private RandomNumberGenerator srand = RandomNumberGenerator.Create();

--- a/src/Samples/WinFormsSample/WinFormsSample.csproj
+++ b/src/Samples/WinFormsSample/WinFormsSample.csproj
@@ -17,6 +17,7 @@
   <PropertyGroup Condition="$(OS) == 'Windows_NT'">
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   
   <!-- Remove files with Windows specific contents on non-Windows platforms -->

--- a/src/Tests/IntegrationTests/TestAsyncAwaitDeadlocks.cs
+++ b/src/Tests/IntegrationTests/TestAsyncAwaitDeadlocks.cs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 
-#if !NET452
+#if !NET46
 using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;

--- a/src/Tests/IntegrationTests/TestAuthorization.cs
+++ b/src/Tests/IntegrationTests/TestAuthorization.cs
@@ -191,7 +191,7 @@ namespace IntegrationTests
             }
         }
 
-#if NET452
+#if NET46
         [Fact]
         public void TestReconnectAuthTimeoutLateClose()
         {

--- a/src/Tests/IntegrationTests/TestBasic.cs
+++ b/src/Tests/IntegrationTests/TestBasic.cs
@@ -891,7 +891,7 @@ namespace IntegrationTests
             }
         }
 
-#if NET452
+#if NET46
         // This test method tests mulitiple overlapping requests across many
         // threads.  The responder simulates work, to introduce variablility
         // in the request timing.
@@ -1784,4 +1784,5 @@ namespace IntegrationTests
         }
 
     } // class
+
 } // namespace

--- a/src/Tests/IntegrationTests/TestEncoding.cs
+++ b/src/Tests/IntegrationTests/TestEncoding.cs
@@ -33,7 +33,7 @@ namespace IntegrationTests
 
         public IEncodedConnection DefaultEncodedConnection => Context.OpenEncodedConnectionWithDefaultTimeout(Context.Server1.Port);
 
-#if NET452
+#if NET46
         [Serializable]
         public class SerializationTestObj
         {
@@ -312,7 +312,7 @@ namespace IntegrationTests
             using (MemoryStream stream = new MemoryStream())
             {
                 serializer.WriteObject(stream, obj);
-#if NET452
+#if NET46
                 byte[] buffer = stream.GetBuffer();
                 long len = stream.Position;
                 var rv = new byte[len];

--- a/src/Tests/IntegrationTests/TestTLS.cs
+++ b/src/Tests/IntegrationTests/TestTLS.cs
@@ -49,7 +49,7 @@ namespace IntegrationTests
                     UnitTestUtilities.GetFullCertificatePath("server-cert.pem"));
 
             // UNSAFE hack for testing purposes.
-#if NET452
+#if NET46
             var isOK = serverCert.GetRawCertDataString().Equals(certificate.GetRawCertDataString());
 #else
             var isOK = serverCert.Issuer.Equals(certificate.Issuer);
@@ -292,7 +292,7 @@ namespace IntegrationTests
             }
         }
 
-#if NET452
+#if NET46
         [Fact]
         public void TestTlsReconnectAuthTimeoutLateClose()
         {

--- a/src/Tests/IntegrationTests/TestUtilities.cs
+++ b/src/Tests/IntegrationTests/TestUtilities.cs
@@ -18,7 +18,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using NATS.Client;
-#if NET452
+#if NET46
 using System.Reflection;
 #endif
 
@@ -26,7 +26,7 @@ namespace IntegrationTests
 {
     public class NATSServer : IDisposable
     {
-#if NET452
+#if NET46
         static readonly string SERVEREXE = "nats-server.exe";
 #else
         static readonly string SERVEREXE = "nats-server";

--- a/src/Tests/UnitTests/Internals/InFlightRequestTests.cs
+++ b/src/Tests/UnitTests/Internals/InFlightRequestTests.cs
@@ -29,7 +29,7 @@ namespace UnitTests.Internals
             var sut = new InFlightRequest("Foo", default, 1, _ => { });
 
             // Assert
-            await Assert.ThrowsAsync<NATSTimeoutException>(() => sut.Task);
+            await Assert.ThrowsAsync<NATSTimeoutException>(() => sut.Waiter.Task);
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace UnitTests.Internals
             var sut = new InFlightRequest("Foo", cts.Token, 1, _ => { });
 
             // Assert
-            await Assert.ThrowsAsync<NATSTimeoutException>(() => sut.Task);
+            await Assert.ThrowsAsync<NATSTimeoutException>(() => sut.Waiter.Task);
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace UnitTests.Internals
             cts.Cancel();
 
             // Assert
-            await Assert.ThrowsAsync<TaskCanceledException>(() => sut.Task);
+            await Assert.ThrowsAsync<TaskCanceledException>(() => sut.Waiter.Task);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace UnitTests.Internals
             cts.Cancel();
 
             // Assert
-            await Assert.ThrowsAsync<TaskCanceledException>(() => sut.Task);
+            await Assert.ThrowsAsync<TaskCanceledException>(() => sut.Waiter.Task);
         }
 
         [Fact]
@@ -83,46 +83,6 @@ namespace UnitTests.Internals
 
             // Assert
             Assert.Equal("Foo", onCompletedArg);
-        }
-
-        [Fact]
-        public async Task TrySetResult_CompletedSuccessfullyWithResult()
-        {
-            // Arrange
-            var msg = new Msg();
-            var sut = new InFlightRequest("Subject", default, 0, _ => {});
-            
-            // Act
-            sut.TrySetResult(msg);
-            
-            // Assert
-            Assert.Equal(msg,  await sut.Task);
-        }
-        
-        [Fact]
-        public async Task TrySetCancelled_TaskCanceledExceptionThrownWhenAwaiting()
-        {
-            // Arrange
-            var sut = new InFlightRequest("Subject", default, 0, _ => {});
-            
-            // Act
-            sut.TrySetCanceled();
-            
-            // Assert
-            await Assert.ThrowsAsync<TaskCanceledException>(() => sut.Task);
-        }
-        
-        [Fact]
-        public async Task TrySetException_ExceptionThrownWhenAwaiting()
-        {
-            // Arrange
-            var sut = new InFlightRequest("Subject", default, 0, _ => {});
-            
-            // Act
-            sut.TrySetException(new InvalidOperationException());
-            
-            // Assert
-            await Assert.ThrowsAsync<InvalidOperationException>(() => sut.Task);
         }
 
         [Fact]

--- a/src/Tests/UnitTests/Internals/InFlightRequestTests.cs
+++ b/src/Tests/UnitTests/Internals/InFlightRequestTests.cs
@@ -29,18 +29,18 @@ namespace UnitTests.Internals
             var sut = new InFlightRequest("Foo", default, 1, _ => { });
 
             // Assert
-            await Assert.ThrowsAsync<NATSTimeoutException>(() => sut.Waiter.Task);
+            await Assert.ThrowsAsync<NATSTimeoutException>(() => sut.Task);
         }
 
         [Fact]
-        public async Task TimeoutWithToken_ThrowsTaskCanceledExcpetion()
+        public async Task TimeoutWithToken_ThrowsNATSTimeoutExcpetion()
         {
             // Arrange
             var cts = new CancellationTokenSource();
             var sut = new InFlightRequest("Foo", cts.Token, 1, _ => { });
 
             // Assert
-            await Assert.ThrowsAsync<NATSTimeoutException>(() => sut.Waiter.Task);
+            await Assert.ThrowsAsync<NATSTimeoutException>(() => sut.Task);
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace UnitTests.Internals
             cts.Cancel();
 
             // Assert
-            await Assert.ThrowsAsync<TaskCanceledException>(() => sut.Waiter.Task);
+            await Assert.ThrowsAsync<TaskCanceledException>(() => sut.Task);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace UnitTests.Internals
             cts.Cancel();
 
             // Assert
-            await Assert.ThrowsAsync<TaskCanceledException>(() => sut.Waiter.Task);
+            await Assert.ThrowsAsync<TaskCanceledException>(() => sut.Task);
         }
 
         [Fact]
@@ -83,6 +83,46 @@ namespace UnitTests.Internals
 
             // Assert
             Assert.Equal("Foo", onCompletedArg);
+        }
+
+        [Fact]
+        public async Task TrySetResult_CompletedSuccessfullyWithResult()
+        {
+            // Arrange
+            var msg = new Msg();
+            var sut = new InFlightRequest("Subject", default, 0, _ => {});
+            
+            // Act
+            sut.TrySetResult(msg);
+            
+            // Assert
+            Assert.Equal(msg,  await sut.Task);
+        }
+        
+        [Fact]
+        public async Task TrySetCancelled_TaskCanceledExceptionThrownWhenAwaiting()
+        {
+            // Arrange
+            var sut = new InFlightRequest("Subject", default, 0, _ => {});
+            
+            // Act
+            sut.TrySetCanceled();
+            
+            // Assert
+            await Assert.ThrowsAsync<TaskCanceledException>(() => sut.Task);
+        }
+        
+        [Fact]
+        public async Task TrySetException_ExceptionThrownWhenAwaiting()
+        {
+            // Arrange
+            var sut = new InFlightRequest("Subject", default, 0, _ => {});
+            
+            // Act
+            sut.TrySetException(new InvalidOperationException());
+            
+            // Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => sut.Task);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes a deadlock #395 using TaskCreationOptions.RunContinuationsAsynchronously on netstandard1.6.
No integration test because I couldn't make it fail reliably (before the fix). 

Upgraded to net46 since #394 will do it anyways and it avoids an ugly workaround.