### PR TITLE
Add Message Request APIs

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2828,7 +2828,7 @@ namespace NATS.Client
             // offset/count checking covered by publish
 
             if (opts.UseOldRequestStyle)
-                return oldRequest(subject, null, data, offset, count, timeout);
+                return oldRequest(subject, headers, data, offset, count, timeout);
 
             using (var request = setupRequest(timeout, CancellationToken.None))
             {

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -3374,11 +3374,11 @@ namespace NATS.Client
         }
 
         /// <summary>
-        /// Asynchronously sends a request payload and returns the response <see cref="Msg"/>, or throws 
+        /// Asynchronously sends a request message and returns the response <see cref="Msg"/>, or throws 
         /// <see cref="NATSTimeoutException"/> if the <paramref name="timeout"/> expires.
         /// </summary>
         /// <remarks>
-        /// <see cref="RequestAsync(string, byte[], int)"/> will create an unique inbox for this request, sharing a
+        /// <see cref="RequestAsync(Msg, int)"/> will create an unique inbox for this request, sharing a
         /// single subscription for all replies to this <see cref="Connection"/> instance. However, if
         /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription.
         /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
@@ -3417,10 +3417,10 @@ namespace NATS.Client
         }
 
         /// <summary>
-        /// Asynchronously sends a request payload and returns the response <see cref="Msg"/>.
+        /// Asynchronously sends a request message and returns the response <see cref="Msg"/>.
         /// </summary>
         /// <remarks>
-        /// <see cref="RequestAsync(string, byte[])"/> will create an unique inbox for this request, sharing a single
+        /// <see cref="RequestAsync(Msg)"/> will create an unique inbox for this request, sharing a single
         /// subscription for all replies to this <see cref="Connection"/> instance. However, if
         /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription. 
         /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
@@ -3457,12 +3457,12 @@ namespace NATS.Client
         }
 
         /// <summary>
-        /// Asynchronously sends a request payload and returns the response <see cref="Msg"/>, or throws
+        /// Asynchronously sends a request message and returns the response <see cref="Msg"/>, or throws
         /// <see cref="NATSTimeoutException"/> if the <paramref name="timeout"/> expires, while monitoring for 
         /// cancellation requests.
         /// </summary>
         /// <remarks>
-        /// <see cref="RequestAsync(string, byte[], int, CancellationToken)"/> will create an unique inbox for this
+        /// <see cref="RequestAsync(Msg, int, CancellationToken)"/> will create an unique inbox for this
         /// request, sharing a single subscription for all replies to this <see cref="Connection"/> instance. However,
         /// if <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription.
         /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
@@ -3503,11 +3503,11 @@ namespace NATS.Client
         }
 
         /// <summary>
-        /// Asynchronously sends a request payload and returns the response <see cref="Msg"/>, while monitoring for
+        /// Asynchronously sends a request message and returns the response <see cref="Msg"/>, while monitoring for
         /// cancellation requests.
         /// </summary>
         /// <remarks>
-        /// <see cref="RequestAsync(string, byte[], CancellationToken)"/> will create an unique inbox for this request,
+        /// <see cref="RequestAsync(Msg, CancellationToken)"/> will create an unique inbox for this request,
         /// sharing a single subscription for all replies to this <see cref="Connection"/> instance. However, if 
         /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription.
         /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2834,7 +2834,7 @@ namespace NATS.Client
             {
                 request.Token.ThrowIfCancellationRequested();
 
-                publish(subject, string.Concat(globalRequestInbox, ".", request.Id), null, data, offset, count, true);
+                publish(subject, string.Concat(globalRequestInbox, ".", request.Id), headers, data, offset, count, true);
 
                 return request.Waiter.Task.GetAwaiter().GetResult();
             }
@@ -2988,6 +2988,8 @@ namespace NATS.Client
         /// the current connection.</param>
         /// <param name="data">An array of type <see cref="Byte"/> that contains the request data to publish
         /// to the connected NATS server.</param>
+        /// <exception cref="NATSMaxPayloadException"><paramref name="data"/> exceeds the maximum payload size 
+        /// supported by the NATS server.</exception>
         /// <param name="offset">The zero-based byte offset in <paramref name="data"/> at which to begin publishing
         /// bytes to the subject.</param>
         /// <param name="count">The number of bytes to be published to the subject.</param>
@@ -2996,6 +2998,83 @@ namespace NATS.Client
         {
             return request(subject, null, data, offset, count, Timeout.Infinite);
         }
+
+        /// <summary>
+        /// Sends a request payload and returns the response <see cref="Msg"/>, or throws
+        /// <see cref="NATSTimeoutException"/> if the <paramref name="timeout"/> expires.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Request(Msg)"/> will create an unique inbox for this request, sharing a single
+        /// subscription for all replies to this <see cref="Connection"/> instance. However, if 
+        /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription. 
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
+        /// </remarks>
+        /// <param name="message">A NATS <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server.  The reply subject will be overridden.</param>
+        /// <param name="timeout">The number of milliseconds to wait.</param>
+        /// <returns>A <see cref="Msg"/> with the response from the NATS server.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout"/> is less than or equal to zero 
+        /// (<c>0</c>).</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is null.</exception>
+        /// <exception cref="NATSBadSubscriptionException">The <paramref name="message"/> subject is <c>null</c>
+        /// or entirely whitespace.</exception>
+        /// <exception cref="NATSMaxPayloadException"><paramref name="message"/> payload exceeds the maximum payload size 
+        /// supported by the NATS server.</exception>
+        /// <exception cref="NATSConnectionClosedException">The <see cref="Connection"/> is closed.</exception>
+        /// <exception cref="NATSTimeoutException">A timeout occurred while sending the request or receiving the 
+        /// response.</exception>
+        /// <exception cref="NATSException">There was an unexpected exception performing an internal NATS call
+        /// while executing the request. See <see cref="Exception.InnerException"/> for more details.</exception>
+        /// <exception cref="IOException">There was a failure while writing to the network.</exception>
+        public Msg Request(Msg message, int timeout)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException("message");
+            }
+
+            byte[] headerBytes = message.header?.ToByteArray();
+            byte[] data = message.Data;
+            int count = data != null ? data.Length : 0;
+            return request(message.Subject, headerBytes, data, 0, count, timeout);
+        }
+
+        /// <summary>
+        /// Sends a request payload and returns the response <see cref="Msg"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Request(Msg)"/> will create an unique inbox for this request, sharing a single
+        /// subscription for all replies to this <see cref="Connection"/> instance. However, if 
+        /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription. 
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
+        /// </remarks>
+        /// <param name="message">A NATS <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server.  The reply subject will be overridden.</param>
+        /// <returns>A <see cref="Msg"/> with the response from the NATS server.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is null.</exception>
+        /// <exception cref="NATSBadSubscriptionException">The <paramref name="message"/> subject is <c>null</c>
+        /// or entirely whitespace.</exception>
+        /// <exception cref="NATSMaxPayloadException"><paramref name="message"/> payload exceeds the maximum payload size 
+        /// supported by the NATS server.</exception>
+        /// <exception cref="NATSConnectionClosedException">The <see cref="Connection"/> is closed.</exception>
+        /// <exception cref="NATSTimeoutException">A timeout occurred while sending the request or receiving the
+        /// response.</exception>
+        /// <exception cref="NATSException">There was an unexpected exception performing an internal NATS call while
+        /// executing the request. See <see cref="Exception.InnerException"/> for more details.</exception>
+        /// <exception cref="IOException">There was a failure while writing to the network.</exception>
+        public Msg Request(Msg message)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException("message");
+            }
+
+            byte[] headerBytes = message.header?.ToByteArray();
+            byte[] data = message.Data;
+            int count = data != null ? data.Length : 0;
+            return request(message.Subject, headerBytes, data, 0, count, Timeout.Infinite);
+        }
+
 
         private Task<Msg> oldRequestAsync(string subject, byte[] headers, byte[] data, int offset, int count, int timeout, CancellationToken ct)
         {
@@ -3292,6 +3371,177 @@ namespace NATS.Client
         public Task<Msg> RequestAsync(string subject, byte[] data, int offset, int count, CancellationToken token)
         {
             return requestAsync(subject, null, data, offset, count, Timeout.Infinite, token);
+        }
+
+        /// <summary>
+        /// Asynchronously sends a request payload and returns the response <see cref="Msg"/>, or throws 
+        /// <see cref="NATSTimeoutException"/> if the <paramref name="timeout"/> expires.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="RequestAsync(string, byte[], int)"/> will create an unique inbox for this request, sharing a
+        /// single subscription for all replies to this <see cref="Connection"/> instance. However, if
+        /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription.
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
+        /// </remarks>
+        /// <param name="message">A NATS <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server.</param>
+        /// <param name="timeout">The number of milliseconds to wait.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the <see cref="Task{TResult}.Result"/>
+        /// parameter contains a <see cref="Msg"/> with the response from the NATS server.</returns>
+        /// <exception cref="ArgumentException"><paramref name="timeout"/> is less than or equal to zero 
+        /// (<c>0</c>).</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is null.</exception>
+        /// <exception cref="NATSBadSubscriptionException">The <paramref name="message"/> subject is <c>null</c>
+        /// or entirely whitespace.</exception>
+        /// <exception cref="NATSMaxPayloadException"><paramref name="message"/> payload exceeds the maximum payload size
+        /// supported by the NATS server.</exception>
+        /// <exception cref="NATSConnectionClosedException">The <see cref="Connection"/> is closed.</exception>
+        /// <exception cref="NATSTimeoutException">A timeout occurred while sending the request or receiving the
+        /// response.</exception>
+        /// <exception cref="NATSException">There was an unexpected exception performing an internal NATS call
+        /// while executing the request. See <see cref="Exception.InnerException"/> for more details.</exception>
+        /// <exception cref="OperationCanceledException">The asynchronous operation was cancelled or timed out before
+        /// it could be completed.</exception>
+        /// <exception cref="IOException">There was a failure while writing to the network.</exception>
+        public Task<Msg> RequestAsync(Msg message, int timeout)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException("message");
+            }
+
+            byte[] headerBytes = message.header?.ToByteArray();
+            byte[] data = message.Data;
+            int count = data != null ? data.Length : 0;
+            return requestAsync(message.Subject, headerBytes, data, 0, count, timeout, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously sends a request payload and returns the response <see cref="Msg"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="RequestAsync(string, byte[])"/> will create an unique inbox for this request, sharing a single
+        /// subscription for all replies to this <see cref="Connection"/> instance. However, if
+        /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription. 
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
+        /// </remarks>
+        /// <param name="message">A NATS <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the 
+        /// <see cref="Task{TResult}.Result"/> parameter contains a <see cref="Msg"/> with the response from the NATS
+        /// server.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is null.</exception>
+        /// <exception cref="NATSBadSubscriptionException">The <paramref name="message"/> subject is <c>null</c>
+        /// or entirely whitespace.</exception>
+        /// <exception cref="NATSMaxPayloadException"><paramref name="message"/> payload exceeds the maximum payload size 
+        /// supported by the NATS server.</exception>
+        /// <exception cref="NATSConnectionClosedException">The <see cref="Connection"/> is closed.</exception>
+        /// <exception cref="NATSTimeoutException">A timeout occurred while sending the request or receiving the
+        /// response.</exception>
+        /// <exception cref="NATSException">There was an unexpected exception performing an internal NATS call while
+        /// executing the request. See <see cref="Exception.InnerException"/> for more details.</exception>
+        /// <exception cref="OperationCanceledException">The asynchronous operation was cancelled or timed out before
+        /// it could be completed.</exception>
+        /// <exception cref="IOException">There was a failure while writing to the network.</exception>
+        public Task<Msg> RequestAsync(Msg message)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException("message");
+            }
+
+            byte[] headerBytes = message.header?.ToByteArray();
+            byte[] data = message.Data;
+            int count = data != null ? data.Length : 0;
+            return requestAsync(message.Subject, headerBytes, data, 0, count, Timeout.Infinite, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously sends a request payload and returns the response <see cref="Msg"/>, or throws
+        /// <see cref="NATSTimeoutException"/> if the <paramref name="timeout"/> expires, while monitoring for 
+        /// cancellation requests.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="RequestAsync(string, byte[], int, CancellationToken)"/> will create an unique inbox for this
+        /// request, sharing a single subscription for all replies to this <see cref="Connection"/> instance. However,
+        /// if <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription.
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
+        /// </remarks>
+        /// <param name="message">A NATS <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server.</param>
+        /// <param name="timeout">The number of milliseconds to wait.</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the
+        /// <see cref="Task{TResult}.Result"/> parameter contains  a <see cref="Msg"/> with the response from the NATS
+        /// server.</returns>
+        /// <exception cref="ArgumentException"><paramref name="timeout"/> is less than or equal to zero
+        /// (<c>0</c>).</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is null.</exception>
+        /// <exception cref="NATSBadSubscriptionException">The <paramref name="message"/> subject is <c>null</c>
+        /// or entirely whitespace.</exception>
+        /// <exception cref="NATSMaxPayloadException"><paramref name="message"/> payload exceeds the maximum payload size
+        /// supported by the NATS server.</exception>
+        /// <exception cref="NATSConnectionClosedException">The <see cref="Connection"/> is closed.</exception>
+        /// <exception cref="NATSTimeoutException">A timeout occurred while sending the request or receiving the
+        /// response.</exception>
+        /// <exception cref="NATSException">There was an unexpected exception performing an internal NATS call while
+        /// executing the request. See <see cref="Exception.InnerException"/> for more details.</exception>
+        /// <exception cref="OperationCanceledException">The asynchronous operation was cancelled or timed out before
+        /// it could be completed.</exception>
+        /// <exception cref="IOException">There was a failure while writing to the network.</exception>
+        public Task<Msg> RequestAsync(Msg message, int timeout, CancellationToken token)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException("message");
+            }
+
+            byte[] headerBytes = message.header?.ToByteArray();
+            byte[] data = message.Data;
+            int count = data != null ? data.Length : 0;
+            return requestAsync(message.Subject, headerBytes, data, 0, count, timeout, token);
+        }
+
+        /// <summary>
+        /// Asynchronously sends a request payload and returns the response <see cref="Msg"/>, while monitoring for
+        /// cancellation requests.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="RequestAsync(string, byte[], CancellationToken)"/> will create an unique inbox for this request,
+        /// sharing a single subscription for all replies to this <see cref="Connection"/> instance. However, if 
+        /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription.
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
+        /// </remarks>
+        /// <param name="message">A NATS <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server.</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the
+        /// <see cref="Task{TResult}.Result"/> parameter contains a <see cref="Msg"/> with the response from the NATS 
+        /// server.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> is null.</exception>
+        /// <exception cref="NATSBadSubscriptionException">The <paramref name="message"/> subject is <c>null</c>
+        /// or entirely whitespace.</exception>
+        /// <exception cref="NATSMaxPayloadException"><paramref name="message"/> payload exceeds the maximum payload size
+        /// supported by the NATS server.</exception>
+        /// <exception cref="NATSConnectionClosedException">The <see cref="Connection"/> is closed.</exception>
+        /// <exception cref="NATSTimeoutException">A timeout occurred while sending the request or receiving the 
+        /// response.</exception>
+        /// <exception cref="NATSException">There was an unexpected exception performing an internal NATS call while 
+        /// executing the request. See <see cref="Exception.InnerException"/> for more details.</exception>
+        /// <exception cref="OperationCanceledException">The asynchronous operation was cancelled or timed out before it
+        /// could be completed.</exception>
+        /// <exception cref="IOException">There was a failure while writing to the network.</exception>
+        public Task<Msg> RequestAsync(Msg message, CancellationToken token)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException("message");
+            }
+
+            byte[] headerBytes = message.header?.ToByteArray();
+            byte[] data = message.Data;
+            int count = data != null ? data.Length : 0;
+            return requestAsync(message.Subject, headerBytes, data, 0, count, Timeout.Infinite, token);
         }
 
         /// <summary>

--- a/src/NATS.Client/IConnection.cs
+++ b/src/NATS.Client/IConnection.cs
@@ -382,6 +382,117 @@ namespace NATS.Client
         Task<Msg> RequestAsync(string subject, byte[] data, int offset, int count, CancellationToken token);
 
         /// <summary>
+        /// Sends a request message and returns the response <see cref="Msg"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>NATS supports two flavors of request-reply messaging: point-to-point or one-to-many. Point-to-point
+        /// involves the fastest or first to respond. In a one-to-many exchange, you set a limit on the number of 
+        /// responses the requestor may receive and instead must use a subscription (<see cref="ISubscription.AutoUnsubscribe(int)"/>).
+        /// In a request-response exchange, publish request operation publishes a message with a reply subject expecting
+        /// a response on that reply subject.</para>
+        /// <para><see cref="Request(Msg)"/> will create an unique inbox for this request, sharing a single
+        /// subscription for all replies to this <see cref="Connection"/> instance. However, if 
+        /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription. 
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.</para>
+        /// </remarks>=
+        /// <param name="message">A <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server.  Any reply subject will be overridden.</param>
+        /// <returns>A <see cref="Msg"/> with the response from the NATS server.</returns>
+        Msg Request(Msg message);
+
+        /// <summary>
+        /// Sends a request message and returns the response <see cref="Msg"/>, or throws
+        /// <see cref="NATSTimeoutException"/> if the <paramref name="timeout"/> expires.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Request(Msg, int)"/> will create an unique inbox for this request, sharing a single
+        /// subscription for all replies to this <see cref="Connection"/> instance. However, if 
+        /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription. 
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
+        /// </remarks>
+        /// <param name="message">A NATS <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server.  The reply subject will be overridden.</param>
+        /// <param name="timeout">The number of milliseconds to wait.</param>
+        /// <returns>A <see cref="Msg"/> with the response from the NATS server.</returns>
+        /// <seealso cref="IConnection.Request(Msg)"/>
+        Msg Request(Msg message, int timeout);
+
+        /// <summary>
+        /// Asynchronously sends a request message and returns the response <see cref="Msg"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="RequestAsync(Msg)"/> will create an unique inbox for this request, sharing a single
+        /// subscription for all replies to this <see cref="Connection"/> instance. However, if
+        /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription. 
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
+        /// </remarks>
+        /// <param name="message">A NATS <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server. The reply subject will be overridden.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the 
+        /// <see cref="Task{TResult}.Result"/> parameter contains a <see cref="Msg"/> with the response from the NATS
+        /// server.</returns>
+        /// <seealso cref="IConnection.Request(Msg)"/>
+        Task<Msg> RequestAsync(Msg message);
+
+        /// <summary>
+        /// Asynchronously sends a request message and returns the response <see cref="Msg"/>, or throws 
+        /// <see cref="NATSTimeoutException"/> if the <paramref name="timeout"/> expires.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="RequestAsync(Msg, int)"/> will create an unique inbox for this request, sharing a
+        /// single subscription for all replies to this <see cref="Connection"/> instance. However, if
+        /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription.
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
+        /// </remarks>
+        /// <param name="message">A NATS message <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server. The reply subject will be overridden.</param>
+        /// <param name="timeout">The number of milliseconds to wait.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the <see cref="Task{TResult}.Result"/>
+        /// parameter contains a <see cref="Msg"/> with the response from the NATS server.</returns>
+        /// <seealso cref="IConnection.Request(Msg, int)"/>
+        Task<Msg> RequestAsync(Msg message, int timeout);
+
+        /// <summary>
+        /// Asynchronously sends a request message and returns the response <see cref="Msg"/>, while monitoring for
+        /// cancellation requests.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="RequestAsync(Msg, CancellationToken)"/> will create an unique inbox for this request,
+        /// sharing a single subscription for all replies to this <see cref="Connection"/> instance. However, if 
+        /// <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription.
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
+        /// </remarks>
+        /// <param name="message">A NATS <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server.  The reply subject will be overridden.</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the
+        /// <see cref="Task{TResult}.Result"/> parameter contains a <see cref="Msg"/> with the response from the NATS 
+        /// server.</returns>
+        /// <seealso cref="IConnection.Request(Msg)"/>
+        Task<Msg> RequestAsync(Msg message, CancellationToken token);
+
+        /// <summary>
+        /// Asynchronously sends a request message and returns the response <see cref="Msg"/>, or throws
+        /// <see cref="NATSTimeoutException"/> if the <paramref name="timeout"/> expires, while monitoring for 
+        /// cancellation requests.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="RequestAsync(Msg, int, CancellationToken)"/> will create an unique inbox for this
+        /// request, sharing a single subscription for all replies to this <see cref="Connection"/> instance. However,
+        /// if <see cref="Options.UseOldRequestStyle"/> is set, each request will have its own underlying subscription.
+        /// The old behavior is not recommended as it may cause unnecessary overhead on connected NATS servers.
+        /// </remarks>
+        /// <param name="message">A NATS <see cref="Msg"/> that contains the request data to publish
+        /// to the connected NATS server.  The reply subject will be overridden.</param>
+        /// <param name="timeout">The number of milliseconds to wait.</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the
+        /// <see cref="Task{TResult}.Result"/> parameter contains  a <see cref="Msg"/> with the response from the NATS
+        /// server.</returns>
+        /// <seealso cref="IConnection.Request(Msg, int)"/>
+        Task<Msg> RequestAsync(Msg message, int timeout, CancellationToken token);
+
+        /// <summary>
         /// Creates an inbox string which can be used for directed replies from subscribers.
         /// </summary>
         /// <remarks>

--- a/src/NATS.Client/Msg.cs
+++ b/src/NATS.Client/Msg.cs
@@ -618,7 +618,16 @@ namespace NATS.Client
                 header = value;
             }
         }
+
+        /// <summary>
+        /// Returns true if there is a <see cref="MsgHeader"/> with fields set.
+        /// </summary>
+        public bool HasHeaders
+        {
+            get
+            {
+                return header?.Count > 0;
+            }
+        }
     }
-
-
 }

--- a/src/Tests/IntegrationTests/TestBasic.cs
+++ b/src/Tests/IntegrationTests/TestBasic.cs
@@ -918,12 +918,12 @@ namespace IntegrationTests
 
                     c.SubscribeAsync("foo", (obj, args) =>
                     {
-                        var m = args.Message;
-                        if (m.HasHeaders)
+                        var msg = args.Message;
+                        if (msg.HasHeaders)
                         {
-                            validHeader = "bar".Equals(m.Header["foo"]);
+                            validHeader = "bar".Equals(msg.Header["foo"]);
                         }
-                        m.Respond(response);
+                        msg.Respond(response);
                     });
 
                     Msg rmsg = new Msg();

--- a/src/Tests/IntegrationTests/TestBasic.cs
+++ b/src/Tests/IntegrationTests/TestBasic.cs
@@ -934,7 +934,7 @@ namespace IntegrationTests
                     Msg m = c.Request(rmsg, 5000);
                     Assert.True(compare(response, m.Data), "Response #1 isn't valid");
 
-                    Assert.True(validHeader);
+                    Assert.True(validHeader, "Header is not valid");
 
                     // test both APIs.
                     m = c.Request(rmsg);


### PR DESCRIPTION
Add Request and RequestAsync APIs to support requests passing a NATS message (and thus supporting headers).

Resolves #409

Signed-off-by: Colin Sullivan <colin@synadia.com>