### PR TITLE
Feature:  Lame Duck Mode Support

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2336,17 +2336,10 @@ namespace NATS.Client
             info = ServerInfo.CreateFromJson(json);
             var discoveredUrls = info.connect_urls;
 
-            // The array could be empty/not present on initial connect,
-            // if advertise is disabled on that server, or servers that
+            // The discoveredUrls array could be empty/not present on initial
+            // connect if advertise is disabled on that server, or servers that
             // did not include themselves in the async INFO protocol.
-            // If empty, do not remove the implicit servers from the pool.
-            if (discoveredUrls?.Length == 0)
-            {
-                if (notify && info.ldm && opts.LameDuckModeEventHandler != null) {
-                    scheduleConnEvent(opts.LameDuckModeEventHandler);
-		        }
-                return;
-            }   
+            // If empty, do not remove the implicit servers from the pool.  
 
             // Note about pool randomization: when the pool was first created,
             // it was randomized (if allowed). We keep the order the same (removing

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2326,7 +2326,7 @@ namespace NATS.Client
         // processInfo is used to parse the info messages sent
         // from the server.
         // Caller must lock.
-        internal void processInfo(string json, bool notifyOnServerAddition)
+        internal void processInfo(string json, bool notify)
         {
             if (json == null || IC._EMPTY_.Equals(json))
             {
@@ -2335,7 +2335,19 @@ namespace NATS.Client
 
             info = ServerInfo.CreateFromJson(json);
             var discoveredUrls = info.connect_urls;
- 
+
+            // The array could be empty/not present on initial connect,
+            // if advertise is disabled on that server, or servers that
+            // did not include themselves in the async INFO protocol.
+            // If empty, do not remove the implicit servers from the pool.
+            if (discoveredUrls?.Length == 0)
+            {
+                if (notify && info.ldm && opts.LameDuckModeEventHandler != null) {
+                    scheduleConnEvent(opts.LameDuckModeEventHandler);
+		        }
+                return;
+            }   
+
             // Note about pool randomization: when the pool was first created,
             // it was randomized (if allowed). We keep the order the same (removing
             // implicit servers that are no longer sent to us). New URLs are sent
@@ -2347,10 +2359,15 @@ namespace NATS.Client
                 // the entire list.
                 srvPool.PruneOutdatedServers(discoveredUrls);
                 var serverAdded = srvPool.Add(discoveredUrls, true);
-                if (notifyOnServerAddition && serverAdded)
+                if (notify && serverAdded)
                 {
                     scheduleConnEvent(opts.ServerDiscoveredEventHandler);
                 }
+            }
+
+            if (notify && info.ldm && opts.LameDuckModeEventHandler != null)
+            {
+                scheduleConnEvent(opts.LameDuckModeEventHandler);
             }
         }
 

--- a/src/NATS.Client/Info.cs
+++ b/src/NATS.Client/Info.cs
@@ -43,6 +43,8 @@ namespace NATS.Client
 
         public int proto { get; private set; }
 
+        public bool ldm { get; private set; }
+
         public static ServerInfo CreateFromJson(string json)
         {
             var x = JSON.Parse(json);
@@ -61,6 +63,7 @@ namespace NATS.Client
                 nonce = x["nonce"].Value,
                 proto = x["proto"].AsInt,
                 headers = x["headers"].AsBool,
+                ldm = x["ldm"].AsBool,
             };
         }
     }

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -75,6 +75,17 @@ namespace NATS.Client
         public EventHandler<ErrEventArgs> AsyncErrorEventHandler = null;
 
         /// <summary>
+        /// Represents the method that will handle an event raised
+        /// when the server notifies the connection that it entered lame duck mode.
+        /// </summary>
+        /// <remarks>
+        /// A server in lame duck mode will gradually disconnect all its connections
+        /// before shuting down. This is often used in deployments when upgrading
+        /// NATS Servers.
+        /// </remarks>
+        public EventHandler<ConnEventArgs> LameDuckModeEventHandler = null;
+
+        /// <summary>
         /// Represents the optional method that is used to get from the
         /// user the desired delay the client should pause before attempting
         /// to reconnect again.
@@ -223,6 +234,7 @@ namespace NATS.Client
             UserJWTEventHandler = o.UserJWTEventHandler;
             UserSignatureEventHandler = o.UserSignatureEventHandler;
             ReconnectDelayHandler = o.ReconnectDelayHandler;
+            LameDuckModeEventHandler = o.LameDuckModeEventHandler;
             maxPingsOut = o.maxPingsOut;
             maxReconnect = o.maxReconnect;
             name = o.name;
@@ -748,7 +760,8 @@ namespace NATS.Client
             appendEventHandler(sb, "ReconnectedEventHandler", ReconnectedEventHandler);
             appendEventHandler(sb, "ReconnectDelayHandler", ReconnectDelayHandler);
             appendEventHandler(sb, "ServerDiscoveredEventHandler", ServerDiscoveredEventHandler);
- 
+            appendEventHandler(sb, "LameDuckModeEventHandler", LameDuckModeEventHandler);
+
             sb.AppendFormat("MaxPingsOut={0};", MaxPingsOut);
             sb.AppendFormat("MaxReconnect={0};", MaxReconnect);
             sb.AppendFormat("Name={0};", Name != null ? Name : "null");

--- a/src/Tests/IntegrationTests/TestSuite.cs
+++ b/src/Tests/IntegrationTests/TestSuite.cs
@@ -252,4 +252,16 @@ namespace IntegrationTests
         public readonly TestServerInfo Server2 = new TestServerInfo(SeedPort + 1);
         public readonly TestServerInfo Server3 = new TestServerInfo(SeedPort + 2);
     }
+
+    public sealed class SkipPlatformsWithoutSignals : FactAttribute
+    {
+        public SkipPlatformsWithoutSignals()
+        {
+            if (NATSServer.SupportsSignals == false)
+            {
+                Skip = "Ignore environments that do not support signaling.";
+            }
+        }
+
+    }
 }


### PR DESCRIPTION
The NATS Server can enter lame duck mode, whereupon it sends an INFO message with "ldm" enabled to clients.  The NATS client library can notify applications, allowing them to clean up, drain their connection, and gracefully connect to another server.

This PR adds a connection event handler to support this functionality, along with associated tests.  While supported on every platform, tests are only performed on systems that support signaling (not windows).

Resolves #399

Signed-off-by: Colin Sullivan <colin@synadia.com>