### PR TITLE
Add No-Responders Feature

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2757,9 +2757,7 @@ namespace NATS.Client
             InFlightRequest request;
             bool isClosed;
 
-            var m = args.Message;
-
-            if (m == null)
+            if (args.Message == null)
                 return;
 
             var subject = args.Message.Subject;
@@ -2800,13 +2798,13 @@ namespace NATS.Client
 
             if (!isClosed)
             {
-                if (IsNoRespondersMsg(m))
+                if (IsNoRespondersMsg(args.Message))
                 {
                     request.Waiter.TrySetException(new NATSNoRespondersException());
                 }
                 else
                 {
-                    request.Waiter.TrySetResult(m);
+                    request.Waiter.TrySetResult(args.Message);
                 }
             }
             else

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2747,7 +2747,9 @@ namespace NATS.Client
 
         private static bool IsNoRespondersMsg(Msg m)
         {
-            return m != null && m.HasHeaders && MsgHeader.noResponders.Equals(m.Header[MsgHeader.Status]);
+            return m != null && m.HasHeaders &&
+                MsgHeader.noResponders.Equals(m.Header[MsgHeader.Status]) &&
+                m.Data.Length == 0;
         }
 
         private void RequestResponseHandler(object sender, MsgHandlerEventArgs args)

--- a/src/NATS.Client/Exceptions.cs
+++ b/src/NATS.Client/Exceptions.cs
@@ -182,7 +182,7 @@ namespace NATS.Client
 
     /// <summary>
     /// The exception thrown when the server has detected there are no responders for a request.
-    /// /// </summary>
+    /// </summary>
     /// <remarks>
     /// This is circuit breaking behavior from the NATS server to more quickly identify when
     /// a request would have timed out.

--- a/src/NATS.Client/Exceptions.cs
+++ b/src/NATS.Client/Exceptions.cs
@@ -179,4 +179,16 @@ namespace NATS.Client
     {
         public NATSConnectionDrainingException() : base("Connection is draining.") { }
     }
+
+    /// <summary>
+    /// The exception thrown when the server has detected there are no responders for a request.
+    /// /// </summary>
+    /// <remarks>
+    /// This is circuit breaking behavior from the NATS server to more quickly identify when
+    /// a request would have timed out.
+    /// </remarks>
+    public class NATSNoRespondersException : NATSTimeoutException
+    {
+        public NATSNoRespondersException() : base("No responders are available for the request.") { }
+    }
 }

--- a/src/NATS.Client/Info.cs
+++ b/src/NATS.Client/Info.cs
@@ -100,6 +100,8 @@ namespace NATS.Client
 
         public bool headers { get; private set; }
 
+        public bool no_responders { get; private set; }
+
         internal ConnectInfo(bool verbose, bool pedantic, string ujwt, string nkey, string sig, 
             string user, string pass, string token, bool secure, string name, bool echo)
         {
@@ -115,6 +117,7 @@ namespace NATS.Client
             this.auth_token = token;
             this.echo = echo;
             this.headers = true;
+            this.no_responders = true;
         }
 
         internal StringBuilder AppendAsJsonTo(StringBuilder sb)
@@ -136,6 +139,7 @@ namespace NATS.Client
                 ["sig"] = sig ?? string.Empty,
                 ["echo"] = echo,
                 ["headers"] = headers,
+                ["no_responders"] = no_responders,
             };
 
             n.WriteToStringBuilder(sb, 0, 0, JSONTextMode.Compact);

--- a/src/NATS.Client/Msg.cs
+++ b/src/NATS.Client/Msg.cs
@@ -491,13 +491,16 @@ namespace NATS.Client
             }
 
             // make a deep copy of the bytes for this message.
-            if (totalLen > 0)
+            long payloadLen = totalLen - arg.hdr;
+            if (payloadLen > 0)
             {
-                data = new byte[totalLen];
-                Array.Copy(payload, (int)arg.hdr, data, 0, (int)(totalLen-arg.hdr));
+                data = new byte[payloadLen];
+                Array.Copy(payload, (int)arg.hdr, data, 0, (int)(totalLen - arg.hdr));
             }
             else
+            {
                 data = Empty;
+            }
         }
 
         /// <summary>

--- a/src/Tests/UnitTests/TestMessageHeaders.cs
+++ b/src/Tests/UnitTests/TestMessageHeaders.cs
@@ -86,10 +86,23 @@ namespace UnitTests
             mh = new MsgHeader(hb, hb.Length);
             Assert.Equal(":::", mh["foo"]);
 
-            // Test empty headers, which may come from teh server.
+            // Test empty headers, which may come from the server.
             hb = Encoding.UTF8.GetBytes($"NATS/1.0\r\n\r\n");
             mh = new MsgHeader(hb, hb.Length);
             Assert.True(mh.Count == 0);
+
+            // Test inline status which will come from the server.
+            hb = Encoding.UTF8.GetBytes($"NATS/1.0 503\r\n\r\n");
+            mh = new MsgHeader(hb, hb.Length);
+            Assert.True(mh.Count == 1);
+            Assert.True(MsgHeader.noResponders.Equals(mh[MsgHeader.Status]));
+
+            // Test inline status with kv pair.
+            hb = Encoding.UTF8.GetBytes($"NATS/1.0 503\r\nfoo:bar\r\n\r\n");
+            mh = new MsgHeader(hb, hb.Length);
+            Assert.True(mh.Count == 2);
+            Assert.Equal(MsgHeader.noResponders, mh[MsgHeader.Status]);
+            Assert.Equal("bar", mh["foo"]);
         }
 
         [Fact]

--- a/src/Tests/UnitTests/TestMessageHeaders.cs
+++ b/src/Tests/UnitTests/TestMessageHeaders.cs
@@ -95,7 +95,7 @@ namespace UnitTests
             hb = Encoding.UTF8.GetBytes($"NATS/1.0 503\r\n\r\n");
             mh = new MsgHeader(hb, hb.Length);
             Assert.True(mh.Count == 1);
-            Assert.True(MsgHeader.noResponders.Equals(mh[MsgHeader.Status]));
+            Assert.Equal(MsgHeader.noResponders, mh[MsgHeader.Status]);
 
             // Test inline status with kv pair.
             hb = Encoding.UTF8.GetBytes($"NATS/1.0 503\r\nfoo:bar\r\n\r\n");


### PR DESCRIPTION
## Add the No Responders Client Feature

Resolves #400 

When a request is made from the client, if the server detects there is no interest in the request subject (no subscribers), it will immediately return a status header indicating there are no responders.  When this happens, the client will throw a new `NATSNoRespondersException` indicating there are no responders available for a request.  This circuit breaking behavior allows applications to avoid waiting for timeouts for requests that NATS can detect will fail.

The `NATSNoRespondersException` is a subclass of the `NATSTimeoutException` in an effort to maintain some backward compatibility.

Signed-off-by: Colin Sullivan <colin@synadia.com>