### PR TITLE
comma issue

### DIFF
--- a/src/NATS.Client/Msg.cs
+++ b/src/NATS.Client/Msg.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2015-2020 The NATS Authors
+// Copyright 2015-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -357,7 +357,10 @@ namespace NATS.Client
             StringBuilder sb = new StringBuilder(MsgHeader.Header);
             foreach (string s in nvc.Keys)
             {
-                sb.AppendFormat("{0}:{1}\r\n", s, this[s]);
+                foreach (string v in nvc.GetValues(s))
+                {
+                    sb.AppendFormat("{0}:{1}\r\n", s, v);
+                }
             }
             sb.Append("\r\n");
             return sb.ToString();


### PR DESCRIPTION
So I built some test code to understand how the .Net code writes the headers, and I think there is a problem if the value contains a comma. Consider this header:
```
Header1: Foo
```
When this is serialized, the result will look like:
```
Header1: Foo␍␊
```

Now consider this data where the key has multiple values.
```
Header1: Foo
Header1: Comma,Inside
```

When this is serialized the result is:
```
Header1: Foo,Comma,Inside␍␊
```
My guess is that when this de-serializes the header ends up as:
```
Header1: Foo
Header1: Comma
Header1: Inside
```

which is not what is desired. This could be circumvented by changing the serialization as in the proposed code which would serialize like this 
```
Header1: Foo␍␊Header1: Comma,Inside␍␊
```
