### PR TITLE
[Added] CreateUserSeed and CreateAccountSeed so these can be generated

### DIFF
--- a/src/NATS.Client/NKeys.cs
+++ b/src/NATS.Client/NKeys.cs
@@ -12,6 +12,8 @@
 // limitations under the License.
 using NATS.Client.NaCl;
 using System;
+using System.IO;
+using System.Text;
 
 namespace NATS.Client
 {
@@ -231,8 +233,7 @@ namespace NATS.Client
                 src.Remove(0);
         }
 
-
-        private static byte[] DecodeSeed(byte[] raw)
+        internal static byte[] DecodeSeed(byte[] raw)
         {
             // Need to do the reverse here to get back to internal representation.
             byte b1 = (byte)(raw[0] & 248);  // 248 = 11111000
@@ -261,7 +262,7 @@ namespace NATS.Client
             }
         }
 
-        private static byte[] DecodeSeed(string src)
+        internal static byte[] DecodeSeed(string src)
         {
             return DecodeSeed(Nkeys.Decode(src));
         }
@@ -271,7 +272,7 @@ namespace NATS.Client
         /// </summary>
         /// <param name="seed"></param>
         /// <returns>A NATS Ed25519 Keypair</returns>
-        static public NkeyPair FromSeed(string seed)
+        public static NkeyPair FromSeed(string seed)
         {
             byte[] userSeed = DecodeSeed(seed);
             try
@@ -283,6 +284,60 @@ namespace NATS.Client
             {
                 Wipe(ref userSeed);
             }
+        }
+
+        internal static string EncodeSeed(byte prefixbyte, byte[] src)
+        {
+            if (!IsValidPublicPrefixByte(prefixbyte))
+                throw new NATSException("Invalid prefix");
+
+            if (src.Length != 32)
+                throw new NATSException("Invalid seed size");
+
+            // In order to make this human printable for both bytes, we need to do a little
+            // bit manipulation to setup for base32 encoding which takes 5 bits at a time.
+            byte b1 = (byte) (PrefixByteSeed | (prefixbyte >> 5));
+            byte b2 = (byte) ((prefixbyte & 31) << 3); // 31 = 00011111
+
+            MemoryStream stream = new MemoryStream();
+            stream.WriteByte(b1);
+            stream.WriteByte(b2);
+
+            // write payload
+            stream.Write(src, 0, src.Length);
+
+            // Calculate and write crc16 checksum
+            byte[] checksum = BitConverter.GetBytes(Crc16.Checksum(stream.ToArray()));
+            stream.Write(checksum, 0, checksum.Length);
+
+            return Base32.Encode(stream.ToArray());
+        }
+
+        private static string CreateSeed(byte prefixbyte) {
+            byte[] rawSeed = new byte[32];
+
+            Random rnd = new Random();
+            rnd.NextBytes(rawSeed);
+
+            return EncodeSeed(prefixbyte, rawSeed);
+        }
+
+        /// <summary>
+        /// Creates a private user seed String.
+        /// </summary>
+        /// <returns>A NATS Ed25519 User Seed</returns>
+        public static string CreateUserSeed()
+        {
+            return CreateSeed(PrefixByteUser);
+        }
+
+        /// <summary>
+        /// Creates a private account seed String.
+        /// </summary>
+        /// <returns>A NATS Ed25519 Account Seed</returns>
+        public static string CreateAccountSeed()
+        {
+            return CreateSeed(PrefixByteAccount);
         }
     }
 }

--- a/src/NATS.Client/NKeys.cs
+++ b/src/NATS.Client/NKeys.cs
@@ -339,5 +339,14 @@ namespace NATS.Client
         {
             return CreateSeed(PrefixByteAccount);
         }
+
+        /// <summary>
+        /// Creates a private operator seed String.
+        /// </summary>
+        /// <returns>A NATS Ed25519 Operator Seed</returns>
+        public static string CreateOperatorSeed()
+        {
+            return CreateSeed(PrefixByteOperator);
+        }
     }
 }

--- a/src/Tests/UnitTests/TestNkeys.cs
+++ b/src/Tests/UnitTests/TestNkeys.cs
@@ -1,0 +1,56 @@
+// Copyright 2021-2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using NATS.Client;
+using Xunit;
+
+namespace UnitTests
+{
+#pragma warning disable CS0618
+    public class TestNkeys
+    { 
+        [Fact]
+        public void TestNKEYEncodeDecode()
+        {
+            byte[] a = new Byte[32];
+            byte[] b = Nkeys.DecodeSeed( Nkeys.EncodeSeed(20 << 3, a));
+            Assert.Equal(a, b);
+            
+            Random rnd = new Random();
+            rnd.NextBytes(a);
+            b = Nkeys.DecodeSeed( Nkeys.EncodeSeed(20 << 3, a));
+            Assert.Equal(a, b);
+        }
+        
+        [Fact]
+        public void TestNKEYCreateUserSeed()
+        {
+            string user = Nkeys.CreateUserSeed();
+            Assert.NotEmpty(user);
+            NkeyPair uk = Nkeys.FromSeed(user);
+            Assert.NotNull(uk);
+        }
+        
+        [Fact]
+        public void TestNKEYCreateAccountSeed()
+        {
+            string acc = Nkeys.CreateAccountSeed();
+            Assert.NotEmpty(acc);
+            NkeyPair uk = Nkeys.FromSeed(acc);
+            Assert.NotNull(uk);
+        }
+    }
+    
+#pragma warning restore CS0618
+}

--- a/src/Tests/UnitTests/TestNkeys.cs
+++ b/src/Tests/UnitTests/TestNkeys.cs
@@ -38,17 +38,23 @@ namespace UnitTests
         {
             string user = Nkeys.CreateUserSeed();
             Assert.NotEmpty(user);
-            NkeyPair uk = Nkeys.FromSeed(user);
-            Assert.NotNull(uk);
+            Assert.NotNull(Nkeys.FromSeed(user));
         }
-        
+
         [Fact]
         public void TestNKEYCreateAccountSeed()
         {
             string acc = Nkeys.CreateAccountSeed();
             Assert.NotEmpty(acc);
-            NkeyPair uk = Nkeys.FromSeed(acc);
-            Assert.NotNull(uk);
+            Assert.NotNull(Nkeys.FromSeed(acc));
+        }
+
+        [Fact]
+        public void TestNKEYCreateOperatorSeed()
+        {
+            string op = Nkeys.CreateOperatorSeed();
+            Assert.NotEmpty(op);
+            Assert.NotNull(Nkeys.FromSeed(op));
         }
     }
     


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

altered visibility for some functions for testing.
Since nkeys don't store the type I am not returning an NKEY and return the seed instead.
That seed can then be used to create the nkey.
