### PR TITLE
serialize header multiple values for one key on separate lines

### DIFF
--- a/src/NATS.Client/Msg.cs
+++ b/src/NATS.Client/Msg.cs
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 using System;
-using System.Text;
 using System.Collections;
 using System.Collections.Specialized;
+using System.Text;
 
 namespace NATS.Client
 {
@@ -398,11 +398,13 @@ namespace NATS.Client
 
         private string ToHeaderString()
         {
-            // TODO:  optimize based on perf testing
             StringBuilder sb = new StringBuilder(MsgHeader.Header);
             foreach (string s in nvc.Keys)
             {
-                sb.AppendFormat("{0}:{1}\r\n", s, this[s]);
+                foreach (string v in nvc.GetValues(s))
+                {
+                    sb.AppendFormat("{0}:{1}\r\n", s, v);
+                }
             }
             sb.Append("\r\n");
             return sb.ToString();

--- a/src/Tests/UnitTests/TestMessageHeaders.cs
+++ b/src/Tests/UnitTests/TestMessageHeaders.cs
@@ -193,25 +193,37 @@ namespace UnitTests
         }
 
         [Fact]
+        public void TestHeaderMultiValueSerialization()
+        {
+            string headers = $"NATS/1.0\r\nfoo:bar\r\nfoo:baz,comma\r\n\r\n";
+            byte[] headerBytes = Encoding.UTF8.GetBytes(headers);
+            var mh = new MsgHeader(headerBytes, headerBytes.Length);
+
+            byte[] bytes = mh.ToByteArray();
+            Assert.True(bytes.Length == headerBytes.Length);
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                Assert.True(headerBytes[i] == bytes[i]);
+            }
+        }
+
+        [Fact]
         public void TestHeaderMultiValues()
         {
             var mh = new MsgHeader();
             mh.Add("foo", "bar");
-            mh.Add("foo", "baz");
+            mh.Add("foo", "baz,comma");
 
-            Assert.Equal("bar,baz", mh["foo"]);
-
-            // Test the GetValues API, don't make assumpions about
-            // order.
+            // Test the GetValues API, don't make assumptions about order.
             string []values = mh.GetValues("foo");
             Assert.True(values.Length == 2);
             List<string> results = new List<string>(values);
             Assert.Contains("bar", results);
-            Assert.Contains("baz", results);
+            Assert.Contains("baz,comma", results);
 
             byte[] bytes = mh.ToByteArray();
             var mh2 = new MsgHeader(bytes, bytes.Length);
-            Assert.Equal("bar,baz", mh2["foo"]);
+            Assert.Equal("bar,baz,comma", mh2["foo"]);
 
             // test the API on a single value key
             mh = new MsgHeader();


### PR DESCRIPTION
Consider this header:
```
Header1:Foo
```
When this is serialized, the result will look like:
```
Header1:Foo␍␊
```

Now consider this data where the key has 2 values, the second has a comma in it's data
```
Header1:Foo
Header1:Comma,Inside
```

When this is serialized by .NET it ends up like this.
```
Header1:Foo,Comma,Inside␍␊
```
Clients, including .NET will then de-serialize as 3 values, 
```
Header1:Foo
Header1:Comma
Header1:Inside
```
which is not what is desired. This PR changes the serialization to serialize like this 
```
Header1:Foo␍␊Header1:Comma,Inside␍␊
```