### PR TITLE
Added test methods to create NATS server with JetStream enabled.

### DIFF
--- a/src/Tests/IntegrationTests/TestUtilities.cs
+++ b/src/Tests/IntegrationTests/TestUtilities.cs
@@ -72,6 +72,30 @@ namespace IntegrationTests
         public static NATSServer CreateFast(int port, string args = null)
             => new NATSServer(TimeSpan.Zero, port, args);
 
+        public static NATSServer CreateJetStreamFast(string args = null)
+            => CreateJetStreamFast(Defaults.Port, args);
+
+        public static NATSServer CreateJetStreamFast(int port, string args = null)
+        {
+            args = args == null
+                ? $"-js"
+                : $"{args} -js";
+
+            return new NATSServer(TimeSpan.Zero, port, args); 
+        }
+
+        public static NATSServer CreateJetStreamFastAndVerify(string args = null)
+            => CreateFastAndVerify(Defaults.Port, args);
+
+        public static NATSServer CreateJetStreamFastAndVerify(int port, string args = null)
+        {
+            args = args == null
+                ? $"-js"
+                : $"{args} -js";
+
+            return CreateFastAndVerify(port, args);
+        }
+
         public static NATSServer CreateFastAndVerify(string args = null)
             => CreateFastAndVerify(Defaults.Port, args);
 

--- a/src/Tests/IntegrationTests/TestUtilities.cs
+++ b/src/Tests/IntegrationTests/TestUtilities.cs
@@ -85,7 +85,7 @@ namespace IntegrationTests
         }
 
         public static NATSServer CreateJetStreamFastAndVerify(string args = null)
-            => CreateFastAndVerify(Defaults.Port, args);
+            => CreateJetStreamFastAndVerify(Defaults.Port, args);
 
         public static NATSServer CreateJetStreamFastAndVerify(int port, string args = null)
         {


### PR DESCRIPTION
Added test methods to create NATS server with JetStream enabled.

@ColinSullivan1 Methods with a new name were created so there would not be ambiguity on nullable parameters if just the CreateFast(...) or CreateFastAndVerify(...) are invoked. Let me know your thoughts or what would be beneficial to be extended.