### PR TITLE
Omit Base32 padding when encoding NKeys

### DIFF
--- a/src/NATS.Client/NATS.cs
+++ b/src/NATS.Client/NATS.cs
@@ -456,14 +456,14 @@ namespace NATS.Client
                 nextChar = (byte)((b << bitsRemaining) & 31);
             }
 
-            //if we didn't end with a full char
-            if (arrayIndex != charCount)
+            // if we didn't end with a full char
+            if (arrayIndex < charCount)
             {
                 returnArray[arrayIndex++] = ValueToChar(nextChar);
-                while (arrayIndex != charCount) returnArray[arrayIndex++] = '='; //padding
+                // NOTE: Base32 padding omitted
             }
 
-            return new string(returnArray);
+            return new string(returnArray, 0, arrayIndex);
         }
 
         private static int CharToValue(char c)

--- a/src/NATS.Client/NKeys.cs
+++ b/src/NATS.Client/NKeys.cs
@@ -14,6 +14,7 @@ using NATS.Client.NaCl;
 using System;
 using System.IO;
 using System.Text;
+using System.Security.Cryptography;
 
 namespace NATS.Client
 {
@@ -318,11 +319,14 @@ namespace NATS.Client
             return Base32.Encode(stream.ToArray());
         }
 
-        private static string CreateSeed(byte prefixbyte) {
+        private static string CreateSeed(byte prefixbyte)
+        {
             byte[] rawSeed = new byte[32];
 
-            Random rnd = new Random();
-            rnd.NextBytes(rawSeed);
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(rawSeed);
+            }
 
             return Encode(prefixbyte, true, rawSeed);
         }

--- a/src/Tests/UnitTests/TestNkeys.cs
+++ b/src/Tests/UnitTests/TestNkeys.cs
@@ -38,6 +38,7 @@ namespace UnitTests
         {
             string user = Nkeys.CreateUserSeed();
             Assert.NotEmpty(user);
+            Assert.False(user.EndsWith("=", StringComparison.Ordinal));
             Assert.NotNull(Nkeys.FromSeed(user));
             string pk = Nkeys.PublicKeyFromSeed(user);
             Assert.Equal('U', pk[0]);
@@ -48,6 +49,7 @@ namespace UnitTests
         {
             string acc = Nkeys.CreateAccountSeed();
             Assert.NotEmpty(acc);
+            Assert.False(acc.EndsWith("=", StringComparison.Ordinal));
             Assert.NotNull(Nkeys.FromSeed(acc));
             string pk = Nkeys.PublicKeyFromSeed(acc);
             Assert.Equal('A', pk[0]);
@@ -58,6 +60,7 @@ namespace UnitTests
         {
             string op = Nkeys.CreateOperatorSeed();
             Assert.NotEmpty(op);
+            Assert.False(op.EndsWith("=", StringComparison.Ordinal));
             Assert.NotNull(Nkeys.FromSeed(op));
             string pk = Nkeys.PublicKeyFromSeed(op);
             Assert.Equal('O', pk[0]);


### PR DESCRIPTION
As seen on Slack, our .NET client apparently applies padding to Base32 encoded strings in line with the RFC but not in line with the other NATS clients. This removes the padding to match the Go client:
https://github.com/nats-io/nkeys/blob/44384414044304395985410ff55ed78cbf0b09a8/strkey.go#L52-L53

Also fixes #466.