### PR TITLE
Optimized handling of messages arriving late after unsubscribe.

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2168,18 +2168,8 @@ namespace NATS.Client
                 stats.inMsgs++;
                 stats.inBytes += length;
 
-                // In regular message processing, the key should be present,
-                // so optimize by using an an exception to handle a missing key.
-                // (as opposed to checking with Contains or TryGetValue)
-                try
-                {
-                    s = subs[msgArgs.sid];
-                }
-                catch (Exception)
-                {
-                    // this can happen when a subscriber is unsubscribing.
-                    return;
-                }
+                if (!subs.TryGetValue(msgArgs.sid, out s))
+                    return; // this can happen when a subscriber is unsubscribing.
 
                 lock (s.mu)
                 {


### PR DESCRIPTION
The existing optimization using the `Dictionary` indexer (`subs[msgArgs.sid]`) is actually not faster than `TryGetValue`. Because of the additional try-catch-block it might even be a little slower. 
But using the indexer becomes dramatically slower when entering the bad path where the subscription does no longer exist. An exception object has to be constructed, thrown and catched...

The .NET Framework does a key lookup in both cases and, if not found returns `false` in `TryGetValue` but throws a `KeyNotFoundException` in the indexer. 
Have a look at the .net refrence sources: 
[Indexer](https://referencesource.microsoft.com/#mscorlib/system/collections/generic/dictionary.cs,181)
[TryGetValue()](https://referencesource.microsoft.com/#mscorlib/system/collections/generic/dictionary.cs,499)

Using a Jetstream consumer I could see around 1000 messages coming in for a subscription after it has been unsubscribed and removed from the `Dictionary`. In such cases this optimization becomes very relevant.