### PR TITLE
Added netstandard2.0 target

### DIFF
--- a/src/NATS.Client/NATS.Client.csproj
+++ b/src/NATS.Client/NATS.Client.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netstandard1.6;net46</TargetFrameworks>
-    <TargetFramework Condition="$(OS) != 'Windows_NT'">netstandard1.6</TargetFramework>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netstandard1.6;netstandard2.0;net46</TargetFrameworks>
+    <TargetFramework Condition="$(OS) != 'Windows_NT'">netstandard1.6;netstandard2.0</TargetFramework>
     <Title>NATS .NET Client</Title>
     <Description>NATS acts as a central nervous system for distributed systems at scale for IoT, edge computing, and cloud native and on-premise applications.  This is the .NET client API.</Description>
     <PackageId>NATS.Client</PackageId>
@@ -37,7 +37,7 @@
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard1.6' Or $(TargetFramework) == 'net46'">
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
Added a "netstandard2.0" target to NATS.Client.csproj to simplify the transitive dependency hierarchy for modern projects.