### PR TITLE
Fix the default reconnect delay

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -722,6 +722,11 @@ namespace NATS.Client
         {
             opts = new Options(options);
 
+            if (opts.ReconnectDelayHandler == null)
+            {
+                opts.ReconnectDelayHandler = DefaultReconnectDelayHandler;
+            }
+
             PING_P_BYTES = Encoding.UTF8.GetBytes(IC.pingProto);
             PING_P_BYTES_LEN = PING_P_BYTES.Length;
 
@@ -1620,7 +1625,7 @@ namespace NATS.Client
                             // If unset, the default handler will be called which uses an
                             // auto reset event to wait, unless kicked out of a close
                             // call.
-                            opts?.ReconnectDelayHandler(this, new ReconnectDelayEventArgs(wlf - 1));
+                            opts.ReconnectDelayHandler(this, new ReconnectDelayEventArgs(wlf - 1));
                         }
                         catch { } // swallow user exceptions
                     }

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -1622,10 +1622,7 @@ namespace NATS.Client
                     {
                         try
                         {
-                            // If unset, the default handler will be called which uses an
-                            // auto reset event to wait, unless kicked out of a close
-                            // call.
-                            opts.ReconnectDelayHandler(this, new ReconnectDelayEventArgs(wlf - 1));
+                            opts?.ReconnectDelayHandler(this, new ReconnectDelayEventArgs(wlf - 1));
                         }
                         catch { } // swallow user exceptions
                     }

--- a/src/NATS.Client/NATS.cs
+++ b/src/NATS.Client/NATS.cs
@@ -191,11 +191,6 @@ namespace NATS.Client
         public static EventHandler<ErrEventArgs> DefaultAsyncErrorEventHandler() => 
             (sender, e) => WriteError("AsyncErrorEvent", e);
 
-        public static EventHandler<ReconnectDelayEventArgs> DefaultReconnectDelayHandler() => (sender, e) =>
-        {
-            Console.Error.WriteLine($"ReconnectDelay Attempts: {e.Attempts}");
-        };
-
         public static EventHandler<HeartbeatAlarmEventArgs> DefaultHeartbeatAlarmEventHandler() =>
             (sender, e) =>
                 WriteEvent("HeartbeatAlarm", e,

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -49,35 +49,35 @@ namespace NATS.Client
         /// Represents the method that will handle an event raised 
         /// when a connection is closed.
         /// </summary>
-        public EventHandler<ConnEventArgs> ClosedEventHandler = null;
+        public EventHandler<ConnEventArgs> ClosedEventHandler;
         public EventHandler<ConnEventArgs> ClosedEventHandlerOrDefault => ClosedEventHandler ?? DefaultClosedEventHandler();
 
         /// <summary>
         /// Represents the method that will handle an event raised
         /// whenever a new server has joined the cluster.
         /// </summary>
-        public EventHandler<ConnEventArgs> ServerDiscoveredEventHandler = null;
+        public EventHandler<ConnEventArgs> ServerDiscoveredEventHandler;
         public EventHandler<ConnEventArgs> ServerDiscoveredEventHandlerOrDefault => ServerDiscoveredEventHandler ?? DefaultServerDiscoveredEventHandler();
 
         /// <summary>
         /// Represents the method that will handle an event raised 
         /// when a connection has been disconnected from a server.
         /// </summary>
-        public EventHandler<ConnEventArgs> DisconnectedEventHandler = null;
+        public EventHandler<ConnEventArgs> DisconnectedEventHandler;
         public EventHandler<ConnEventArgs> DisconnectedEventHandlerOrDefault => DisconnectedEventHandler ?? DefaultDisconnectedEventHandler();
 
         /// <summary>
         /// Represents the method that will handle an event raised 
         /// when a connection has reconnected to a server.
         /// </summary>
-        public EventHandler<ConnEventArgs> ReconnectedEventHandler = null;
+        public EventHandler<ConnEventArgs> ReconnectedEventHandler;
         public EventHandler<ConnEventArgs> ReconnectedEventHandlerOrDefault => ReconnectedEventHandler ?? DefaultReconnectedEventHandler();
 
         /// <summary>
         /// Represents the method that will handle an event raised 
         /// when an error occurs out of band.
         /// </summary>
-        public EventHandler<ErrEventArgs> AsyncErrorEventHandler = null;
+        public EventHandler<ErrEventArgs> AsyncErrorEventHandler;
         public EventHandler<ErrEventArgs> AsyncErrorEventHandlerOrDefault => AsyncErrorEventHandler ?? DefaultAsyncErrorEventHandler();
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace NATS.Client
         /// before shuting down. This is often used in deployments when upgrading
         /// NATS Servers.
         /// </remarks>
-        public EventHandler<ConnEventArgs> LameDuckModeEventHandler = null;
+        public EventHandler<ConnEventArgs> LameDuckModeEventHandler;
         public EventHandler<ConnEventArgs> LameDuckModeEventHandlerOrDefault => LameDuckModeEventHandler ?? DefaultLameDuckModeEventHandler();
 
         /// <summary>
@@ -104,24 +104,24 @@ namespace NATS.Client
         /// zero and <see cref="Options.ReconnectJitter"/> or
         /// <see cref="Options.ReconnectJitterTLS"/>
         /// </remarks>
-        public EventHandler<ReconnectDelayEventArgs> ReconnectDelayHandler = null;
+        public EventHandler<ReconnectDelayEventArgs> ReconnectDelayHandler;
 
         /// <summary>
         /// Represents the method that will handle an heartbeat alarm
         /// </summary>
-        public EventHandler<HeartbeatAlarmEventArgs> HeartbeatAlarmEventHandler = null;
+        public EventHandler<HeartbeatAlarmEventArgs> HeartbeatAlarmEventHandler;
         public EventHandler<HeartbeatAlarmEventArgs> HeartbeatAlarmEventHandlerOrDefault => HeartbeatAlarmEventHandler ?? DefaultHeartbeatAlarmEventHandler();
 
         /// <summary>
         /// Represents the method that will handle a unknown or unhandled status event
         /// </summary>
-        public EventHandler<UnhandledStatusEventArgs> UnhandledStatusEventHandler = null;
+        public EventHandler<UnhandledStatusEventArgs> UnhandledStatusEventHandler;
         public EventHandler<UnhandledStatusEventArgs> UnhandledStatusEventHandlerOrDefault => UnhandledStatusEventHandler ?? DefaultUnhandledStatusEventHandler();
 
         /// <summary>
         /// Represents the method that will handle a flow control processed event
         /// </summary>
-        public EventHandler<FlowControlProcessedEventArgs> FlowControlProcessedEventHandler = null;
+        public EventHandler<FlowControlProcessedEventArgs> FlowControlProcessedEventHandler;
         public EventHandler<FlowControlProcessedEventArgs> FlowControlProcessedEventHandlerOrDefault => FlowControlProcessedEventHandler ?? DefaultFlowControlProcessedEventHandler();
         
         /// <summary>

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -49,35 +49,35 @@ namespace NATS.Client
         /// Represents the method that will handle an event raised 
         /// when a connection is closed.
         /// </summary>
-        public EventHandler<ConnEventArgs> ClosedEventHandler;
+        public EventHandler<ConnEventArgs> ClosedEventHandler = null;
         public EventHandler<ConnEventArgs> ClosedEventHandlerOrDefault => ClosedEventHandler ?? DefaultClosedEventHandler();
 
         /// <summary>
         /// Represents the method that will handle an event raised
         /// whenever a new server has joined the cluster.
         /// </summary>
-        public EventHandler<ConnEventArgs> ServerDiscoveredEventHandler;
+        public EventHandler<ConnEventArgs> ServerDiscoveredEventHandler = null;
         public EventHandler<ConnEventArgs> ServerDiscoveredEventHandlerOrDefault => ServerDiscoveredEventHandler ?? DefaultServerDiscoveredEventHandler();
 
         /// <summary>
         /// Represents the method that will handle an event raised 
         /// when a connection has been disconnected from a server.
         /// </summary>
-        public EventHandler<ConnEventArgs> DisconnectedEventHandler;
+        public EventHandler<ConnEventArgs> DisconnectedEventHandler = null;
         public EventHandler<ConnEventArgs> DisconnectedEventHandlerOrDefault => DisconnectedEventHandler ?? DefaultDisconnectedEventHandler();
 
         /// <summary>
         /// Represents the method that will handle an event raised 
         /// when a connection has reconnected to a server.
         /// </summary>
-        public EventHandler<ConnEventArgs> ReconnectedEventHandler;
+        public EventHandler<ConnEventArgs> ReconnectedEventHandler = null;
         public EventHandler<ConnEventArgs> ReconnectedEventHandlerOrDefault => ReconnectedEventHandler ?? DefaultReconnectedEventHandler();
 
         /// <summary>
         /// Represents the method that will handle an event raised 
         /// when an error occurs out of band.
         /// </summary>
-        public EventHandler<ErrEventArgs> AsyncErrorEventHandler;
+        public EventHandler<ErrEventArgs> AsyncErrorEventHandler = null;
         public EventHandler<ErrEventArgs> AsyncErrorEventHandlerOrDefault => AsyncErrorEventHandler ?? DefaultAsyncErrorEventHandler();
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace NATS.Client
         /// before shuting down. This is often used in deployments when upgrading
         /// NATS Servers.
         /// </remarks>
-        public EventHandler<ConnEventArgs> LameDuckModeEventHandler;
+        public EventHandler<ConnEventArgs> LameDuckModeEventHandler = null;
         public EventHandler<ConnEventArgs> LameDuckModeEventHandlerOrDefault => LameDuckModeEventHandler ?? DefaultLameDuckModeEventHandler();
 
         /// <summary>
@@ -104,25 +104,24 @@ namespace NATS.Client
         /// zero and <see cref="Options.ReconnectJitter"/> or
         /// <see cref="Options.ReconnectJitterTLS"/>
         /// </remarks>
-        public EventHandler<ReconnectDelayEventArgs> ReconnectDelayHandler;
-        public EventHandler<ReconnectDelayEventArgs> ReconnectDelayHandlerOrDefault => ReconnectDelayHandler ?? DefaultReconnectDelayHandler();
+        public EventHandler<ReconnectDelayEventArgs> ReconnectDelayHandler = null;
 
         /// <summary>
         /// Represents the method that will handle an heartbeat alarm
         /// </summary>
-        public EventHandler<HeartbeatAlarmEventArgs> HeartbeatAlarmEventHandler;
+        public EventHandler<HeartbeatAlarmEventArgs> HeartbeatAlarmEventHandler = null;
         public EventHandler<HeartbeatAlarmEventArgs> HeartbeatAlarmEventHandlerOrDefault => HeartbeatAlarmEventHandler ?? DefaultHeartbeatAlarmEventHandler();
 
         /// <summary>
         /// Represents the method that will handle a unknown or unhandled status event
         /// </summary>
-        public EventHandler<UnhandledStatusEventArgs> UnhandledStatusEventHandler;
+        public EventHandler<UnhandledStatusEventArgs> UnhandledStatusEventHandler = null;
         public EventHandler<UnhandledStatusEventArgs> UnhandledStatusEventHandlerOrDefault => UnhandledStatusEventHandler ?? DefaultUnhandledStatusEventHandler();
 
         /// <summary>
         /// Represents the method that will handle a flow control processed event
         /// </summary>
-        public EventHandler<FlowControlProcessedEventArgs> FlowControlProcessedEventHandler;
+        public EventHandler<FlowControlProcessedEventArgs> FlowControlProcessedEventHandler = null;
         public EventHandler<FlowControlProcessedEventArgs> FlowControlProcessedEventHandlerOrDefault => FlowControlProcessedEventHandler ?? DefaultFlowControlProcessedEventHandler();
         
         /// <summary>

--- a/src/Tests/IntegrationTests/TestConnection.cs
+++ b/src/Tests/IntegrationTests/TestConnection.cs
@@ -13,12 +13,11 @@
 
 using System;
 using System.Collections.Concurrent;
-using NATS.Client;
-using System.Threading;
-using Xunit;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
-using System.Timers;
+using NATS.Client;
+using Xunit;
 
 namespace IntegrationTests
 {
@@ -534,7 +533,7 @@ namespace IntegrationTests
                     int min = (opts.MaxReconnect-1) * opts.ReconnectWait;
 
                     // Wait until we're closed (add slack for slow CI)
-                    Assert.True(closedEv.WaitOne(min + 5000));
+                    Assert.True(closedEv.WaitOne(min + 10000));
 
                     // Ensure we're not earlier than the minimum wait.
                     Assert.False(sw.ElapsedMilliseconds < min,

--- a/src/Tests/IntegrationTests/TestConnection.cs
+++ b/src/Tests/IntegrationTests/TestConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2015-2018 The NATS Authors
+﻿// Copyright 2015-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -534,10 +534,10 @@ namespace IntegrationTests
                     int min = (opts.MaxReconnect-1) * opts.ReconnectWait;
 
                     // Wait until we're closed (add slack for slow CI)
-                    Assert.True(closedEv.WaitOne(min + 1000));
+                    Assert.True(closedEv.WaitOne(min + 5000));
 
                     // Ensure we're not earlier than the minimum wait.
-                    Assert.True(sw.ElapsedMilliseconds >= min,
+                    Assert.False(sw.ElapsedMilliseconds < min,
                         $"Elapsed {sw.ElapsedMilliseconds} ms < expected minimum {min} ms");
                 }
             }


### PR DESCRIPTION
The original default reconnect delay handler was overridden.  Revert back to using the original.

Resolves #547  

Signed-off-by: Colin Sullivan <colin@synadia.com>