### PR TITLE
msbuild: use TargetFrameworks exclusivley to fix overrides

### DIFF
--- a/src/Benchmarks/MicroBenchmarks/MicroBenchmarks.csproj
+++ b/src/Benchmarks/MicroBenchmarks/MicroBenchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework Condition="$(OS) != 'Windows_NT'">netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netcoreapp3.1;net462</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netcoreapp3.1;net46</TargetFrameworks>
-    <TargetFramework Condition="$(OS) != 'Windows_NT'">netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
     <Version>0.0.0</Version>
     <Company>CNCF</Company>
     <Authors>The NATS Authors</Authors>


### PR DESCRIPTION
Currently, mixing `<TargetFramework>` and `<TargetFrameworks>` means that when `Directory.Build.props` is merged, both keys can end up in the configuration, causing the following error on build on Linux:

```
Microsoft.PackageDependencyResolution.targets(267,5): error NETSDK1005: Assets file 'nats.net/src/NATS.Client/obj/project.assets.json' doesn't have a target for 'netcoreapp3.1'. Ensure that restore has run and that you have included 'netcoreapp3.1' in the TargetFrameworks for your project. [nats.net/src/NATS.Client/NATS.Client.csproj]
```

The solution is to only use `<TargetFrameworks>` so that overrides are always applied properly