### PR TITLE
Allow setting CheckCertificateRevocation for encrypted connections

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -443,7 +443,7 @@ namespace NATS.Client
                 try
                 {
                     SslProtocols protocol = (SslProtocols)Enum.Parse(typeof(SslProtocols), "Tls12");
-                    sslStream.AuthenticateAsClientAsync(hostName, options.certificates, protocol, true).Wait();
+                    sslStream.AuthenticateAsClientAsync(hostName, options.certificates, protocol, options.CheckCertificateRevocation).Wait();
                 }
                 catch (Exception ex)
                 {

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -305,6 +305,8 @@ namespace NATS.Client
             {
                 certificates = new X509Certificate2Collection(o.certificates);
             }
+
+            CheckCertificateRevocation = o.CheckCertificateRevocation;
         }
 
         static readonly string[] protcolSep = new[] {"://"};
@@ -769,6 +771,12 @@ namespace NATS.Client
         /// <seealso cref="ReconnectJitter"/>
         /// <seealso cref="SetReconnectJitter(int, int)"/>
         public int ReconnectJitterTLS { get => reconnectJitterTLS; }
+
+        /// <summary>
+        /// Get or set whether to check Certificate Revocation when connecting via TLS
+        /// </summary>
+        /// <seealso cref="SslStream.AuthenticateAsClientAsync(string, X509CertificateCollection, System.Security.Authentication.SslProtocols, bool)"/>
+        public bool CheckCertificateRevocation { get; set; } = true;
 
         /// <summary>
         /// Returns a string representation of the


### PR DESCRIPTION
This allows for use of self-signed certificates.
More info: https://en.wikipedia.org/wiki/Certificate_revocation_list

Gist with sample application using the new option:
https://gist.github.com/LaurensVergote/419aba52093b9cf7529d80cf4ae0af0f

This likely fixes #492

Adding @jens-gellynck (security analyst)