### PR TITLE
[NO MERGE] Replace Monitor with SemaphoreSlim

### DIFF
--- a/src/NATS.Client/AsyncSub.cs
+++ b/src/NATS.Client/AsyncSub.cs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -156,6 +157,16 @@ namespace NATS.Client
         /// for this <see cref="AsyncSubscription"/>.</exception>
         public void Start()
         {
+            StartCore(callerHoldsLock: false);
+        }
+
+        internal void StartUnsynchronized()
+        {
+            StartCore(callerHoldsLock: true);
+        }
+        
+        private void StartCore(bool callerHoldsLock)
+        {
             if (started)
                 return;
 
@@ -164,7 +175,14 @@ namespace NATS.Client
                 if (conn == null)
                     throw new NATSBadSubscriptionException();
 
-                conn.sendSubscriptionMessageSynchronized(this);
+                if (callerHoldsLock)
+                {
+                    conn.sendSubscriptionMessageUnsynchronized(this);
+                }
+                else
+                {
+                    conn.sendSubscriptionMessageSynchronized(this);
+                }
                 enableAsyncProcessing();
             }
         }

--- a/src/NATS.Client/AsyncSub.cs
+++ b/src/NATS.Client/AsyncSub.cs
@@ -164,7 +164,7 @@ namespace NATS.Client
                 if (conn == null)
                     throw new NATSBadSubscriptionException();
 
-                conn.sendSubscriptionMessage(this);
+                conn.sendSubscriptionMessageSynchronized(this);
                 enableAsyncProcessing();
             }
         }

--- a/src/NATS.Client/AsyncSub.cs
+++ b/src/NATS.Client/AsyncSub.cs
@@ -128,7 +128,7 @@ namespace NATS.Client
             started = true;
         }
 
-        private void doAsyncProcessing() => conn.deliverMsgs(mch);
+        private void doAsyncProcessing() => conn.deliverMsgsSynchronized(mch);
 
         internal void disableAsyncProcessing()
         {

--- a/src/NATS.Client/AsyncSub.cs
+++ b/src/NATS.Client/AsyncSub.cs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/NATS.Client/AsyncSub.cs
+++ b/src/NATS.Client/AsyncSub.cs
@@ -42,10 +42,10 @@ namespace NATS.Client
         private bool started = false;
 
  
-        internal AsyncSubscription(Connection conn, string subject, string queue, Channel<Msg> messageChannel)
+        internal AsyncSubscription(Connection conn, string subject, string queue)
             : base(conn, subject, queue)
         {
-            mch = messageChannel;
+            mch = conn.getMessageChannelUnsynchronized();
             if ((ownsChannel = (mch == null)))
             {
                 mch = new Channel<Msg>()

--- a/src/NATS.Client/AsyncSub.cs
+++ b/src/NATS.Client/AsyncSub.cs
@@ -40,10 +40,11 @@ namespace NATS.Client
 
         private bool started = false;
 
-        internal AsyncSubscription(Connection conn, string subject, string queue)
+ 
+        internal AsyncSubscription(Connection conn, string subject, string queue, Channel<Msg> messageChannel)
             : base(conn, subject, queue)
         {
-            mch = conn.getMessageChannel();
+            mch = messageChannel;
             if ((ownsChannel = (mch == null)))
             {
                 mch = new Channel<Msg>()

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -689,23 +689,13 @@ namespace NATS.Client
         /// Gets an available message channel for use with async subscribers.  It will
         /// setup the message channel pool if configured to do so.
         /// </summary>
+        /// <remarks>
+        /// Callers must wait on <see cref="_mutex"/>.
+        /// </remarks>
         /// <returns>
         /// A channel for use, null if configuration dictates not to use the 
         /// channel pool.
         /// </returns>
-        internal Channel<Msg> getMessageChannelSynchronized()
-        {
-            _mutex.Wait();
-            try
-            {
-                return getMessageChannelUnsynchronized();
-            }
-            finally
-            {
-                _mutex.Release(1);
-            }
-        }
-
         internal Channel<Msg> getMessageChannelUnsynchronized()
         {
             if (opts.subscriberDeliveryTaskCount > 0 && subChannelPool == null)

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -20,8 +20,6 @@ using System.IO;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
-using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -353,7 +351,7 @@ namespace NATS.Client
             ///     Client code
             ///          ->NetworkStream/SslStream (srvStream)
             ///              ->TCPClient (srvClient);
-            /// 
+            // NOTE: I think mu could be remove entirely
             object        mu        = new object();
             TcpClient     client    = null;
             NetworkStream stream    = null;

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -3879,7 +3879,7 @@ namespace NATS.Client
 
             enableSubChannelPooling();
             AsyncSubscription s = createAsyncSubscriptionDelegate == null
-                ? new AsyncSubscription(this, subject, queue, messageChannel)
+                ? new AsyncSubscription(this, subject, queue)
                 : createAsyncSubscriptionDelegate(this, subject, queue);
 
             addSubscription(s);

--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -3828,12 +3828,6 @@ namespace NATS.Client
         internal delegate SyncSubscription CreateSyncSubscriptionDelegate(Connection conn, string subject, string queue);
         internal delegate AsyncSubscription CreateAsyncSubscriptionDelegate(Connection conn, string subject, string queue);
 
-        
-        // NOTE: NOT Synchronized when called from JetStream.*
-        // NOTE: NOT Synchronized when called from EncodedConnection.*
-        // NOTE: NOT Synchronized when called from Connection.SubscribeAsync()
-        // NOTE: NOT Synchronized when called from Connection.subscribeAsync()
-        // NOTE: Synchronized when called from setupRequest(int, CancellationToken)
         internal AsyncSubscription subscribeAsyncSynchronized(string subject, string queue,
             EventHandler<MsgHandlerEventArgs> handler, CreateAsyncSubscriptionDelegate createAsyncSubscriptionDelegate = null)
         {
@@ -3846,7 +3840,6 @@ namespace NATS.Client
             {
                 throw new NATSBadSubscriptionException("Invalid queue group name.");
             }
-
 
             _mutex.Wait();
             try

--- a/src/NATS.Client/ConnectionFactory.cs
+++ b/src/NATS.Client/ConnectionFactory.cs
@@ -168,7 +168,7 @@ namespace NATS.Client
             Connection nc = new Connection(opts);
             try
             {
-                nc.connect();
+                nc.connectSynchronized();
             }
             catch (Exception)
             {
@@ -230,7 +230,7 @@ namespace NATS.Client
             EncodedConnection nc = new EncodedConnection(opts);
             try
             {
-                nc.connect();
+                nc.connectSynchronized();
             }
             catch (Exception)
             {

--- a/src/NATS.Client/EncodedConn.cs
+++ b/src/NATS.Client/EncodedConn.cs
@@ -402,7 +402,7 @@ namespace NATS.Client
 
         // when our base (Connection) removes a subscriber, clean up
         // our references to the encoded handler wrapper.
-        internal override void removeSub(Subscription s)
+        internal override void removeSubUnsynchronized(Subscription s)
         {
             // The subscription may not be present - request reply uses
             // a sync subscription which won't be added to the wrappers.
@@ -411,7 +411,7 @@ namespace NATS.Client
                 wrappers.Remove(s);
             }
 
-            base.removeSub(s);
+            base.removeSubUnsynchronized(s);
         }
 
         /// <summary>

--- a/src/NATS.Client/EncodedConn.cs
+++ b/src/NATS.Client/EncodedConn.cs
@@ -273,7 +273,7 @@ namespace NATS.Client
 
             EncodedHandlerWrapper echWrapper = new EncodedHandlerWrapper(this, handler);
 
-            IAsyncSubscription s = base.subscribeAsync(subject, reply,
+            IAsyncSubscription s = base.subscribeAsyncSynchronized(subject, reply,
                 echWrapper.msgHandlerToEncoderHandler);
 
             wrappers.Add(s, echWrapper);

--- a/src/NATS.Client/JetStream/JetStream.cs
+++ b/src/NATS.Client/JetStream/JetStream.cs
@@ -332,7 +332,7 @@ namespace NATS.Client.JetStream
                     return new JetStreamPushAsyncSubscription(lConn, lSubject, lQueue, asm, this, stream, consumerName, inboxDeliver);
                 }
                 
-                sub = ((Connection)Conn).subscribeAsync(inboxDeliver, queueName, handler, CreateAsyncSubDelegate);
+                sub = ((Connection)Conn).subscribeAsyncSynchronized(inboxDeliver, queueName, handler, CreateAsyncSubDelegate);
             }
 
             asm.SetSub(sub);

--- a/src/NATS.Client/JetStream/JetStream.cs
+++ b/src/NATS.Client/JetStream/JetStream.cs
@@ -293,7 +293,7 @@ namespace NATS.Client.JetStream
                     return new JetStreamPullSubscription(lConn, lSubject, asm, this, stream, consumerName, inboxDeliver);
                 }
 
-                sub = ((Connection)Conn).subscribeSync(inboxDeliver, queueName, CreateSubDelegate);
+                sub = ((Connection)Conn).subscribeSyncSynchronized(inboxDeliver, queueName, CreateSubDelegate);
             }
             else if (userHandler == null) {
                 SyncSubscription CreateSubDelegate(Connection lConn, string lSubject, string lQueue)
@@ -301,7 +301,7 @@ namespace NATS.Client.JetStream
                     return new JetStreamPushSyncSubscription(lConn, lSubject, lQueue, asm, this, stream, consumerName, inboxDeliver);
                 }
                 
-                sub = ((Connection)Conn).subscribeSync(inboxDeliver, queueName, CreateSubDelegate); 
+                sub = ((Connection)Conn).subscribeSyncSynchronized(inboxDeliver, queueName, CreateSubDelegate); 
             }
             else
             {

--- a/src/NATS.Client/JetStream/JetStreamPushAsyncSubscription.cs
+++ b/src/NATS.Client/JetStream/JetStreamPushAsyncSubscription.cs
@@ -23,7 +23,7 @@ namespace NATS.Client.JetStream
 
         internal JetStreamPushAsyncSubscription(Connection conn, string subject, string queue,
             IAutoStatusManager asm, JetStream js, string stream, string consumer, string deliver)
-            : base(conn, subject, queue, conn.getMessageChannelUnsynchronized())
+            : base(conn, subject, queue)
         {
             _asm = asm;
             Context = js;

--- a/src/NATS.Client/JetStream/JetStreamPushAsyncSubscription.cs
+++ b/src/NATS.Client/JetStream/JetStreamPushAsyncSubscription.cs
@@ -23,7 +23,7 @@ namespace NATS.Client.JetStream
 
         internal JetStreamPushAsyncSubscription(Connection conn, string subject, string queue,
             IAutoStatusManager asm, JetStream js, string stream, string consumer, string deliver)
-            : base(conn, subject, queue, conn.getMessageChannelSynchronized())
+            : base(conn, subject, queue, conn.getMessageChannelUnsynchronized())
         {
             _asm = asm;
             Context = js;

--- a/src/NATS.Client/JetStream/JetStreamPushAsyncSubscription.cs
+++ b/src/NATS.Client/JetStream/JetStreamPushAsyncSubscription.cs
@@ -23,7 +23,7 @@ namespace NATS.Client.JetStream
 
         internal JetStreamPushAsyncSubscription(Connection conn, string subject, string queue,
             IAutoStatusManager asm, JetStream js, string stream, string consumer, string deliver)
-            : base(conn, subject, queue)
+            : base(conn, subject, queue, conn.getMessageChannelSynchronized())
         {
             _asm = asm;
             Context = js;

--- a/src/NATS.Client/Parser.cs
+++ b/src/NATS.Client/Parser.cs
@@ -236,7 +236,7 @@ namespace NATS.Client
                         int  msgSize  = conn.msgArgs.size;
                         if (msgSize == 0)
                         {
-                            conn.processMsg(msgBufBase, msgSize);
+                            conn.processMsgSynchronized(msgBufBase, msgSize);
                             state = MSG_END;
                         }
                         else
@@ -255,7 +255,7 @@ namespace NATS.Client
 
                             if ((position + writeLen) >= msgSize)
                             {
-                                conn.processMsg(msgBufBase, msgSize);
+                                conn.processMsgSynchronized(msgBufBase, msgSize);
                                 msgBufStream.Position = 0;
                                 state = MSG_END;
                             }
@@ -371,7 +371,7 @@ namespace NATS.Client
                             case '\r':
                                 break;
                             case '\n':
-                                conn.processErr(argBufStream);
+                                conn.processErrSynchronized(argBufStream);
                                 argBufStream.Position = 0;
                                 state = OP_START;
                                 break;

--- a/src/NATS.Client/Subscription.cs
+++ b/src/NATS.Client/Subscription.cs
@@ -272,7 +272,7 @@ namespace NATS.Client
                 return;
             }
 
-            c.unsubscribe(this, 0, false, 0);
+            c.unsubscribeSynchronized(this, 0, false, 0);
         }
 
         /// <summary>
@@ -314,7 +314,7 @@ namespace NATS.Client
                 c = conn;
             }
 
-            c.unsubscribe(this, max, false, 0);
+            c.unsubscribeSynchronized(this, max, false, 0);
         }
 
         /// <summary>
@@ -608,7 +608,7 @@ namespace NATS.Client
                 c = conn;
             }
 
-            return c.unsubscribe(this, 0, true, timeout);
+            return c.unsubscribeSynchronized(this, 0, true, timeout);
         }
 
         public Task DrainAsync()

--- a/src/NATS.Client/SyncSub.cs
+++ b/src/NATS.Client/SyncSub.cs
@@ -125,7 +125,7 @@ namespace NATS.Client
                 if (d == localMax)
                 {
                     // Remove subscription if we have reached max.
-                    localConn.removeSubSafe(this);
+                    localConn.removeSubSynchronized(this);
                 }
 
                 if (localMax > 0 && d > localMax)

--- a/src/Tests/IntegrationTests/TestJetStream.cs
+++ b/src/Tests/IntegrationTests/TestJetStream.cs
@@ -92,6 +92,7 @@ namespace IntegrationTests
             });
         }
 
+        // Failed once with [SUB-90012] Consumer is already bound to a subscription.
         [Fact]
         public void TestJetStreamSubscribe() {
             Context.RunInJsServer(c =>

--- a/src/Tests/IntegrationTests/TestJetStreamManagement.cs
+++ b/src/Tests/IntegrationTests/TestJetStreamManagement.cs
@@ -31,7 +31,7 @@ namespace IntegrationTests
         {
             Context.RunInJsServer(c =>
             {
-                DateTime now = DateTime.Now;
+                DateTime now = DateTime.UtcNow;
 
                 IJetStreamManagement jsm = c.CreateJetStreamManagementContext();
 
@@ -81,7 +81,7 @@ namespace IntegrationTests
         public void TestStreamCreateWithNoSubject() {
             Context.RunInJsServer(c =>
             {
-                DateTime now = DateTime.Now;
+                DateTime now = DateTime.UtcNow;
 
                 IJetStreamManagement jsm = c.CreateJetStreamManagementContext();
 
@@ -91,7 +91,7 @@ namespace IntegrationTests
                     .Build();
 
                 StreamInfo si = jsm.AddStream(sc);
-                Assert.True(now.CompareTo(si.Created) < 0);
+                Assert.True(now <= si.Created, $"now {now:o} <= si.Created {si.Created:o}");
 
                 sc = si.Config;
                 Assert.Equal(STREAM, sc.Name);
@@ -639,7 +639,7 @@ namespace IntegrationTests
                 MsgHeader h = new MsgHeader();
                 h.Add("foo", "bar");
 
-                DateTime beforeCreated = DateTime.Now;
+                DateTime beforeCreated = DateTime.UtcNow;
                 js.Publish(new Msg(SUBJECT, null, h, DataBytes(1)));
                 js.Publish(new Msg(SUBJECT, null));
 
@@ -649,7 +649,7 @@ namespace IntegrationTests
                 Assert.Equal(SUBJECT, mi.Subject);
                 Assert.Equal(Data(1), System.Text.Encoding.ASCII.GetString(mi.Data));
                 Assert.Equal(1U, mi.Sequence);
-                Assert.True(mi.Time >= beforeCreated);
+                Assert.True(mi.Time >= beforeCreated, $"mi.Time: {mi.Time:o} >= beforeCreated: {beforeCreated:o}");
                 Assert.NotNull(mi.Headers);
                 Assert.Equal("bar", mi.Headers["foo"]);
 

--- a/src/Tests/IntegrationTests/TestJetStreamManagement.cs
+++ b/src/Tests/IntegrationTests/TestJetStreamManagement.cs
@@ -639,7 +639,8 @@ namespace IntegrationTests
                 MsgHeader h = new MsgHeader();
                 h.Add("foo", "bar");
 
-                DateTime beforeCreated = DateTime.UtcNow;
+                // Apparently clock is not synchronized between dotnet and nats-server
+                DateTime beforeCreated = DateTime.UtcNow.AddMilliseconds(-30);
                 js.Publish(new Msg(SUBJECT, null, h, DataBytes(1)));
                 js.Publish(new Msg(SUBJECT, null));
 

--- a/src/Tests/IntegrationTests/TestKeyValue.cs
+++ b/src/Tests/IntegrationTests/TestKeyValue.cs
@@ -38,7 +38,7 @@ namespace IntegrationTests
         [Fact]
         public void TestWorkFLow()
         {
-            DateTime now = DateTime.Now;
+            DateTime now = DateTime.UtcNow;
 
             string byteKey = "byteKey";
             string stringKey = "stringKey";
@@ -627,7 +627,7 @@ namespace IntegrationTests
             else {
                 Assert.Null(entry.Value);
             }
-            Assert.True(now.CompareTo(entry.Created) < 0);
+            Assert.True(now <= entry.Created, $"now {now:o} <= entry.Created {entry.Created:o}");
             return entry;
         }
 

--- a/src/Tests/IntegrationTests/TestReconnect.cs
+++ b/src/Tests/IntegrationTests/TestReconnect.cs
@@ -485,6 +485,7 @@ namespace IntegrationTests
             Assert.Throws<ArgumentOutOfRangeException>(() => { opts.ReconnectBufferSize = -2; });
         }
 
+        // NOTE: Extremely flaky
         [Fact]
         public void TestReconnectBufferDisabled()
         {
@@ -526,6 +527,7 @@ namespace IntegrationTests
             }
         }
 
+        // NOTE: Extremely flaky
         [Fact]
         public void TestReconnectBufferBoundary()
         {


### PR DESCRIPTION
This is a first PR in a series of pull requests I have in mind to enable async IO in nats.net. This pull request in itself does not enable async, but is fundamental for it. It replaces all usages of `Monitor` (aka `lock`) in `Connection` with `SemaphoreSlim`.  While `Monitor` only works on sync paths, `SemaphoreSlim` enables sync and async waiting and can be used on async paths too. 

The diff is rather large because `SemaphoreSlim` is not reentrant, thus requiring some changes to when and where we lock on the semaphore. While refactoring, I used `Unsynchronized` as a method name suffix to indicate methods that require synchronization by the caller (precendence https://github.com/dotnet/runtime/search?l=C%23&q=Unsynchronized) and `Synchronized` for methods acquiring a lock themself (caller must not synchronize). Those suffixes can be removed, but I actually found them quite helpful.

I haven't tested these changes thoroughly yet, but unit tests are passing (some are flaky, I tried to fix some and added comments to others).
Plan is to have this PR sit here for some time, revisit it, and collect some feedback, as this is a rather risky change.

nats-io/nats.net#389 nats-io/nats.net.v2#48 nats-io/nats.net.v2#49
