### PR TITLE
subscription before consumer

### DIFF
--- a/src/NATS.Client/JetStream/JetStreamAbstractSyncSubscription.cs
+++ b/src/NATS.Client/JetStream/JetStreamAbstractSyncSubscription.cs
@@ -20,7 +20,7 @@ namespace NATS.Client.JetStream
         internal IAutoStatusManager _asm;
         public JetStream Context { get; }
         public string Stream { get; }
-        public string Consumer { get; }
+        public string Consumer { get; internal set; }
         public string DeliverSubject { get; }
 
         internal JetStreamAbstractSyncSubscription(Connection conn, string subject, string queue,

--- a/src/NATS.Client/JetStream/JetStreamPushAsyncSubscription.cs
+++ b/src/NATS.Client/JetStream/JetStreamPushAsyncSubscription.cs
@@ -18,7 +18,7 @@ namespace NATS.Client.JetStream
         private IAutoStatusManager _asm;
         public JetStream Context { get; }
         public string Stream { get; }
-        public string Consumer { get; }
+        public string Consumer { get; internal set; }
         public string DeliverSubject { get; }
 
         internal JetStreamPushAsyncSubscription(Connection conn, string subject, string queue,


### PR DESCRIPTION
The order of creating a subscription on the server and creating a consumer on the server matters. Once the consumer is created, there is interest and the server tries to deliver. But if the subscription is not created, the messages are delivered to...nowhere, but are considered delivered.

This was not strictly a problem but it was a race - if the subscription was ready before the consumer was sent message, then things went fine. Unit test didn't fail. But when we were testing against NGS and in clusters with mixes of JetStream and non-Jetstream servers, the consumer was always ready because of simple latency.

So now the server subscription is always made first avoiding the problem altogether.