### PR TITLE
remove enforcement of durable name on pull subscriptions

### DIFF
--- a/src/NATS.Client/JetStream/SubscribeOptions.cs
+++ b/src/NATS.Client/JetStream/SubscribeOptions.cs
@@ -49,7 +49,7 @@ namespace NATS.Client.JetStream
             Stream = Validator.ValidateStreamName(builder.Stream, builder.Bind);
             
             string durable = Validator.ValidateMustMatchIfBothSupplied(builder.Durable, builder.Cc?.Durable, JsSoDurableMismatch);
-            durable = Validator.ValidateDurable(durable, pull || builder.Bind);
+            durable = Validator.ValidateDurable(durable, builder.Bind);
 
             deliverGroup = Validator.ValidateMustMatchIfBothSupplied(deliverGroup, builder.Cc?.DeliverGroup, JsSoDeliverGroupMismatch);
 

--- a/src/Tests/UnitTests/JetStream/TestPushPullSubscribeOptions.cs
+++ b/src/Tests/UnitTests/JetStream/TestPushPullSubscribeOptions.cs
@@ -89,14 +89,6 @@ namespace UnitTests.JetStream
             ConsumerConfiguration ccBadDur = ConsumerConfiguration.Builder().WithDurable(HasDot).Build();
             Assert.Throws<ArgumentException>(() => builder1.WithConfiguration(ccBadDur).Build());
 
-            // durable required direct or in configuration
-            PullSubscribeOptions.PullSubscribeOptionsSubscribeOptionsBuilder builder2 = PullSubscribeOptions.Builder();
-
-            Assert.Throws<ArgumentException>(() => builder2.Build());
-
-            ConsumerConfiguration ccNoDur = ConsumerConfiguration.Builder().Build();
-            Assert.Throws<ArgumentException>(() => builder2.WithConfiguration(ccNoDur).Build());
-
             // durable directly
             PullSubscribeOptions.Builder().WithDurable(DURABLE).Build();
 
@@ -144,12 +136,6 @@ namespace UnitTests.JetStream
             Assert.Null(PushSubscribeOptions.Builder().Build().Durable);
 
             // pull
-            Assert.Throws<ArgumentException>(() => PullSubscribeOptions.Builder()
-                .WithDurable(null)
-                .WithConfiguration(ConsumerConfiguration.Builder().WithDurable(null).Build())
-                .Build()
-                .Durable);
-
             Assert.Equal("y", PullSubscribeOptions.Builder()
                 .WithDurable(null)
                 .WithConfiguration(ConsumerConfiguration.Builder().WithDurable("y").Build())
@@ -172,8 +158,6 @@ namespace UnitTests.JetStream
                 .WithDurable("x")
                 .WithConfiguration(ConsumerConfiguration.Builder().WithDurable("y").Build())
                 .Build());
-
-            Assert.Throws<ArgumentException>(() => PullSubscribeOptions.Builder().Build());
         }
 
         [Fact]


### PR DESCRIPTION
Since v2.7.0 the server allows ephemeral pull consumers. This change removes the code that enforced a durable name when making a pull subscription.