### PR TITLE
Server urls connection management

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -2359,27 +2359,31 @@ namespace NATS.Client
             }
 
             info = new ServerInfo(json);
-            var discoveredUrls = info.ConnectURLs;
 
-            // The discoveredUrls array could be empty/not present on initial
-            // connect if advertise is disabled on that server, or servers that
-            // did not include themselves in the async INFO protocol.
-            // If empty, do not remove the implicit servers from the pool.  
-
-            // Note about pool randomization: when the pool was first created,
-            // it was randomized (if allowed). We keep the order the same (removing
-            // implicit servers that are no longer sent to us). New URLs are sent
-            // to us in no specific order so don't need extra randomization.
-            if (discoveredUrls != null && discoveredUrls.Length > 0)
+            if (!opts.IgnoreDiscoveredServers)
             {
-                // Prune out implicit servers no longer needed.  
-                // The Add in srvPool is idempotent, so just add
-                // the entire list.
-                srvPool.PruneOutdatedServers(discoveredUrls);
-                var serverAdded = srvPool.Add(discoveredUrls, true);
-                if (notify && serverAdded)
+                var discoveredUrls = info.ConnectURLs;
+
+                // The discoveredUrls array could be empty/not present on initial
+                // connect if advertise is disabled on that server, or servers that
+                // did not include themselves in the async INFO protocol.
+                // If empty, do not remove the implicit servers from the pool.  
+
+                // Note about pool randomization: when the pool was first created,
+                // it was randomized (if allowed). We keep the order the same (removing
+                // implicit servers that are no longer sent to us). New URLs are sent
+                // to us in no specific order so don't need extra randomization.
+                if (discoveredUrls != null && discoveredUrls.Length > 0)
                 {
-                    scheduleConnEvent(opts.ServerDiscoveredEventHandlerOrDefault);
+                    // Prune out implicit servers no longer needed.  
+                    // The Add in srvPool is idempotent, so just add
+                    // the entire list.
+                    srvPool.PruneOutdatedServers(discoveredUrls);
+                    var serverAdded = srvPool.Add(discoveredUrls, true);
+                    if (notify && serverAdded)
+                    {
+                        scheduleConnEvent(opts.ServerDiscoveredEventHandlerOrDefault);
+                    }
                 }
             }
 

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -36,6 +36,7 @@ namespace NATS.Client
         bool secure = false;
         bool allowReconnect = true;
         bool noEcho = false;
+        bool ignoreDiscoveredServers = false;
         int maxReconnect  = Defaults.MaxReconnect;
         int reconnectWait = Defaults.ReconnectWait;
         int pingInterval  = Defaults.PingInterval;
@@ -268,6 +269,7 @@ namespace NATS.Client
             name = o.name;
             noRandomize = o.noRandomize;
             noEcho = o.noEcho;
+            ignoreDiscoveredServers = o.ignoreDiscoveredServers;
             pedantic = o.pedantic;
             reconnectBufSize = o.reconnectBufSize;
             useOldRequestStyle = o.useOldRequestStyle;
@@ -683,6 +685,11 @@ namespace NATS.Client
         /// </summary>
         public bool NoEcho { get => noEcho; set => noEcho = value; }
 
+        /// <summary>
+        /// Whether or not to ignore discovered servers when considering for connect/reconnect
+        /// </summary>
+        public bool IgnoreDiscoveredServers { get => ignoreDiscoveredServers; set => ignoreDiscoveredServers = value; }
+        
         private void appendEventHandler(StringBuilder sb, String name, Delegate eh)
         {
             if (eh != null)
@@ -798,6 +805,7 @@ namespace NATS.Client
             sb.AppendFormat("Name={0};", Name != null ? Name : "null");
             sb.AppendFormat("NoRandomize={0};", NoRandomize);
             sb.AppendFormat("NoEcho={0};", NoEcho);
+            sb.AppendFormat("IgnoreDiscoveredServers={0};", ignoreDiscoveredServers);
             sb.AppendFormat("Pedantic={0};", Pedantic);
             sb.AppendFormat("UseOldRequestStyle={0};", UseOldRequestStyle);
             sb.AppendFormat("PingInterval={0};", PingInterval);

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -37,6 +37,7 @@ namespace NATS.Client
         bool allowReconnect = true;
         bool noEcho = false;
         bool ignoreDiscoveredServers = false;
+        IServerProvider serverProvider = null;
         int maxReconnect  = Defaults.MaxReconnect;
         int reconnectWait = Defaults.ReconnectWait;
         int pingInterval  = Defaults.PingInterval;
@@ -270,6 +271,7 @@ namespace NATS.Client
             noRandomize = o.noRandomize;
             noEcho = o.noEcho;
             ignoreDiscoveredServers = o.ignoreDiscoveredServers;
+            serverProvider = o.serverProvider;
             pedantic = o.pedantic;
             reconnectBufSize = o.reconnectBufSize;
             useOldRequestStyle = o.useOldRequestStyle;
@@ -689,6 +691,8 @@ namespace NATS.Client
         /// Whether or not to ignore discovered servers when considering for connect/reconnect
         /// </summary>
         public bool IgnoreDiscoveredServers { get => ignoreDiscoveredServers; set => ignoreDiscoveredServers = value; }
+
+        public IServerProvider ServerProvider { get => serverProvider; set => serverProvider = value; }
         
         private void appendEventHandler(StringBuilder sb, String name, Delegate eh)
         {
@@ -806,6 +810,7 @@ namespace NATS.Client
             sb.AppendFormat("NoRandomize={0};", NoRandomize);
             sb.AppendFormat("NoEcho={0};", NoEcho);
             sb.AppendFormat("IgnoreDiscoveredServers={0};", ignoreDiscoveredServers);
+            sb.AppendFormat("ServerProvider={0};", serverProvider == null ? "Default" : "Provided");
             sb.AppendFormat("Pedantic={0};", Pedantic);
             sb.AppendFormat("UseOldRequestStyle={0};", UseOldRequestStyle);
             sb.AppendFormat("PingInterval={0};", PingInterval);

--- a/src/NATS.Client/Srv.cs
+++ b/src/NATS.Client/Srv.cs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 The NATS Authors
+// Copyright 2015-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,57 +15,65 @@ using System;
 
 namespace NATS.Client
 {
-    // Tracks individual backend servers.
-    internal class Srv
+    public interface IServerProvider
     {
-        private const string defaultScheme = "nats://";
-        private const int defaultPort = 4222;
-        private const int noPortSpecified = -1;
-        internal Uri url = null;
-        internal bool didConnect = false;
-        internal int reconnects = 0;
-        internal DateTime lastAttempt = DateTime.Now;
-        internal bool isImplicit = false;
-        private bool secure = false;
+        /// <summary>
+        /// Setup your provider 
+        /// </summary>
+        /// <param name="opts"></param>
+        void Setup(Options opts);
+        Srv First();
+        Srv SelectNextServer(int maxReconnect);
+        string[] GetServerList(bool implicitOnly);
+        void ConnectToAServer(Predicate<Srv> connectToServer);
+        bool HasSecureServer();
+        void SetCurrentServer(Srv value);
+        bool AcceptDiscoveredServers(string[] discoveredUrls);
+    }
+
+    // Tracks individual backend servers.
+    public class Srv
+    {
+        public const string DefaultScheme = "nats://";
+        public const int DefaultPort = 4222;
+        public const int NoPortSpecified = -1;
+        
+        public Uri Url { get; }
+        public bool IsImplicit { get; }
+        public bool Secure { get; }
+        public DateTime LastAttempt { get; private set; }
+        public bool DidConnect { get; set; }
+        public int Reconnects { get; set; }
 
         // never create a srv object without a url.
         private Srv() { }
 
-        internal Srv(string urlString)
+        public Srv(string urlString)
         {
             if (!urlString.Contains("://"))
             {
-                urlString = defaultScheme + urlString;
+                urlString = DefaultScheme + urlString;
             }
             else
             {
-                secure = urlString.Contains("tls://");
+                Secure = urlString.Contains("tls://");
             }
 
             var uri = new Uri(urlString);
 
-            url = uri.Port == noPortSpecified ? new UriBuilder(uri) {Port = defaultPort}.Uri : uri;
+            Url = uri.Port == NoPortSpecified ? new UriBuilder(uri) {Port = DefaultPort}.Uri : uri;
+            
+            LastAttempt = DateTime.Now;
         }
 
-        internal Srv(string urlString, bool isUrlImplicit) : this(urlString)
+        public Srv(string urlString, bool isUrlImplicit) : this(urlString)
         {
-            isImplicit = isUrlImplicit;
+            IsImplicit = isUrlImplicit;
         }
 
-        internal void updateLastAttempt()
-        {
-            lastAttempt = DateTime.Now;
-        }
+        public void UpdateLastAttempt() => LastAttempt = DateTime.Now;
 
-        internal TimeSpan TimeSinceLastAttempt
-        {
-            get
-            {
-                return (DateTime.Now - lastAttempt);
-            }
-        }
-
-        internal bool Secure => secure;
+        public TimeSpan TimeSinceLastAttempt => (DateTime.Now - LastAttempt);
     }
 }
 


### PR DESCRIPTION
1. architecture issue 113 Add option to ignore discovered urls
2. ServersToTryProvider provide a way that a user can provide a complete custom implementation and provide the server urls to try on connect / reconnect. Tiered servers could be implemented this way.