### PR TITLE
consumer info change to sequence_info from sequence_pair

### DIFF
--- a/src/NATS.Client/JetStream/ApiConstants.cs
+++ b/src/NATS.Client/JetStream/ApiConstants.cs
@@ -72,6 +72,7 @@ namespace NATS.Client.JetStream
         internal const string Keep = "keep";
         internal const string Lag = "lag";
         internal const string LameDuckMode = "ldm";
+        internal const string LastActive = "last_active";
         internal const string LastBySubject = "last_by_subj";
         internal const string LastSeq = "last_seq";
         internal const string LastTs = "last_ts";

--- a/src/NATS.Client/JetStream/ConsumerInfo.cs
+++ b/src/NATS.Client/JetStream/ConsumerInfo.cs
@@ -23,8 +23,8 @@ namespace NATS.Client.JetStream
         public string Name { get; private set; }
         public ConsumerConfiguration ConsumerConfiguration { get; private set; }
         public DateTime Created { get; private set; }
-        public SequencePair Delivered { get; private set; }
-        public SequencePair AckFloor { get; private set; }
+        public SequenceInfo Delivered { get; private set; }
+        public SequenceInfo AckFloor { get; private set; }
         public ulong NumPending { get; private set; }
         public long NumWaiting { get; private set; }
         public long NumAckPending { get; private set; }
@@ -54,8 +54,8 @@ namespace NATS.Client.JetStream
             ConsumerConfiguration = new ConsumerConfiguration(ciNode[ApiConstants.Config]);
             Name = ciNode[ApiConstants.Name].Value;
             Created = AsDate(ciNode[ApiConstants.Created]);
-            Delivered = new SequencePair(ciNode[ApiConstants.Delivered]);
-            AckFloor = new SequencePair(ciNode[ApiConstants.AckFloor]);
+            Delivered = new SequenceInfo(ciNode[ApiConstants.Delivered]);
+            AckFloor = new SequenceInfo(ciNode[ApiConstants.AckFloor]);
             NumPending = ciNode[ApiConstants.NumPending].AsUlong;
             NumWaiting = ciNode[ApiConstants.NumWaiting].AsLong;
             NumAckPending = ciNode[ApiConstants.NumAckPending].AsLong;

--- a/src/NATS.Client/JetStream/SequenceInfo.cs
+++ b/src/NATS.Client/JetStream/SequenceInfo.cs
@@ -1,4 +1,4 @@
-// Copyright 2021 The NATS Authors
+// Copyright 2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:
@@ -11,19 +11,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using NATS.Client.Internals.SimpleJSON;
+using static NATS.Client.Internals.JsonUtils;
 
 namespace NATS.Client.JetStream
 {
-    public class SequencePair
+    public sealed class SequenceInfo : SequencePair
     {
-        public ulong ConsumerSeq { get; }
-        public ulong StreamSeq { get; }
+        /// <summary>
+        /// The last time a message was delivered or acknowledged (for ack_floor)
+        /// </summary>
+        public DateTime LastActive { get; }
 
-        internal SequencePair(JSONNode spNode)
+        internal SequenceInfo(JSONNode spNode) : base(spNode)
         {
-            ConsumerSeq = spNode[ApiConstants.ConsumerSeq].AsUlong;
-            StreamSeq = spNode[ApiConstants.StreamSeq].AsUlong;
+            LastActive = AsDate(spNode[ApiConstants.LastActive]); 
         }
 
         public override string ToString()
@@ -31,6 +34,7 @@ namespace NATS.Client.JetStream
             return "{" +
                    "ConsumerSeq=" + ConsumerSeq +
                    ", StreamSeq=" + StreamSeq +
+                   ", LastActive=" + LastActive +
                    '}';
         }
     }

--- a/src/Tests/UnitTests/Data/ConsumerInfo.json
+++ b/src/Tests/UnitTests/Data/ConsumerInfo.json
@@ -14,13 +14,35 @@
   },
   "delivered": {
     "consumer_seq": 1,
-    "stream_seq": 2
+    "stream_seq": 2,
+    "last_active": "2022-06-29T19:33:21.163377Z"
   },
   "ack_floor": {
     "consumer_seq": 3,
-    "stream_seq": 4
+    "stream_seq": 4,
+    "last_active": "2022-06-29T20:33:21.163377Z"
   },
   "num_pending": 24,
   "num_ack_pending": 42,
-  "num_redelivered": 42
+  "num_redelivered": 42,
+  "cluster": {
+    "name": "clustername",
+    "leader": "clusterleader",
+    "replicas": [
+      {
+        "name": "name0",
+        "current": true,
+        "offline": true,
+        "active": 230000000000,
+        "lag": 3
+      },
+      {
+        "name": "name1",
+        "current": false,
+        "offline": false,
+        "active": 240000000000,
+        "lag": 4
+      }
+    ]
+  }
 }


### PR DESCRIPTION
https://github.com/nats-io/nats.net/issues/629

* A new object was created, `SequenceInfo` which extends `SequencePair`
* The `ConsumerInfo.Delivered` and `ConsumerInfo.AckFloor` fields where changed to this type.

Backward compile compatibility was ensured by the subclass, meaning if you assigned `Delivered` to a SequencePair, this is fine, it still is a SequencePair.
