### PR TITLE
Use Utc times for integration tests

### DIFF
--- a/src/Tests/IntegrationTests/TestJetStream.cs
+++ b/src/Tests/IntegrationTests/TestJetStream.cs
@@ -621,7 +621,7 @@ namespace IntegrationTests
                     .WithDeliverPolicy(DeliverPolicy.ByStartTime)
                     .WithDeliverSubject(Deliver(3))
                     .WithDurable(Durable(3))
-                    .WithStartTime(DateTime.Now.AddHours(1))
+                    .WithStartTime(DateTime.UtcNow.AddHours(1))
                     .Build();
                 jsm.AddOrUpdateConsumer(STREAM, cc);
 
@@ -677,7 +677,7 @@ namespace IntegrationTests
                 ChangeExPush(js, PushDurableBuilder().WithFlowControl(10000), "FlowControl");
                 ChangeExPush(js, PushDurableBuilder().WithHeadersOnly(true), "HeadersOnly");
 
-                ChangeExPush(js, PushDurableBuilder().WithStartTime(DateTime.Now), "StartTime");
+                ChangeExPush(js, PushDurableBuilder().WithStartTime(DateTime.UtcNow), "StartTime");
                 ChangeExPush(js, PushDurableBuilder().WithAckWait(Duration.OfMillis(1)), "AckWait");
                 ChangeExPush(js, PushDurableBuilder().WithDescription("x"), "Description");
                 ChangeExPush(js, PushDurableBuilder().WithSampleFrequency("x"), "SampleFrequency");

--- a/src/Tests/IntegrationTests/TestJetStreamManagement.cs
+++ b/src/Tests/IntegrationTests/TestJetStreamManagement.cs
@@ -31,7 +31,7 @@ namespace IntegrationTests
         {
             Context.RunInJsServer(c =>
             {
-                DateTime now = DateTime.UtcNow;
+                DateTime utcNow = DateTime.UtcNow;
 
                 IJetStreamManagement jsm = c.CreateJetStreamManagementContext();
 
@@ -42,7 +42,7 @@ namespace IntegrationTests
                     .Build();
 
                 StreamInfo si = jsm.AddStream(sc);
-                Assert.True(now <= si.Created);
+                Assert.True(utcNow <= si.Created.ToUniversalTime());
 
                 Assert.NotNull(si.Config);
                 sc = si.Config;
@@ -81,7 +81,7 @@ namespace IntegrationTests
         public void TestStreamCreateWithNoSubject() {
             Context.RunInJsServer(c =>
             {
-                DateTime now = DateTime.UtcNow;
+                DateTime utcNow = DateTime.UtcNow;
 
                 IJetStreamManagement jsm = c.CreateJetStreamManagementContext();
 
@@ -91,7 +91,7 @@ namespace IntegrationTests
                     .Build();
 
                 StreamInfo si = jsm.AddStream(sc);
-                Assert.True(now.CompareTo(si.Created) < 0);
+                Assert.True(utcNow <= si.Created.ToUniversalTime());
 
                 sc = si.Config;
                 Assert.Equal(STREAM, sc.Name);
@@ -649,7 +649,7 @@ namespace IntegrationTests
                 Assert.Equal(SUBJECT, mi.Subject);
                 Assert.Equal(Data(1), System.Text.Encoding.ASCII.GetString(mi.Data));
                 Assert.Equal(1U, mi.Sequence);
-                Assert.True(mi.Time >= beforeCreated);
+                Assert.True(mi.Time.ToUniversalTime() >= beforeCreated);
                 Assert.NotNull(mi.Headers);
                 Assert.Equal("bar", mi.Headers["foo"]);
 
@@ -657,7 +657,7 @@ namespace IntegrationTests
                 Assert.Equal(SUBJECT, mi.Subject);
                 Assert.Null(mi.Data);
                 Assert.Equal(2U, mi.Sequence);
-                Assert.True(mi.Time >= beforeCreated);
+                Assert.True(mi.Time.ToUniversalTime() >= beforeCreated);
                 Assert.Null(mi.Headers);
 
                 Assert.True(jsm.DeleteMessage(STREAM, 1));

--- a/src/Tests/IntegrationTests/TestJetStreamManagement.cs
+++ b/src/Tests/IntegrationTests/TestJetStreamManagement.cs
@@ -31,7 +31,7 @@ namespace IntegrationTests
         {
             Context.RunInJsServer(c =>
             {
-                DateTime now = DateTime.Now;
+                DateTime now = DateTime.UtcNow;
 
                 IJetStreamManagement jsm = c.CreateJetStreamManagementContext();
 
@@ -81,7 +81,7 @@ namespace IntegrationTests
         public void TestStreamCreateWithNoSubject() {
             Context.RunInJsServer(c =>
             {
-                DateTime now = DateTime.Now;
+                DateTime now = DateTime.UtcNow;
 
                 IJetStreamManagement jsm = c.CreateJetStreamManagementContext();
 
@@ -639,7 +639,7 @@ namespace IntegrationTests
                 MsgHeader h = new MsgHeader();
                 h.Add("foo", "bar");
 
-                DateTime beforeCreated = DateTime.Now;
+                DateTime beforeCreated = DateTime.UtcNow; //MessageInfo.Time is in UTC
                 js.Publish(new Msg(SUBJECT, null, h, DataBytes(1)));
                 js.Publish(new Msg(SUBJECT, null));
 

--- a/src/Tests/IntegrationTests/TestKeyValue.cs
+++ b/src/Tests/IntegrationTests/TestKeyValue.cs
@@ -39,7 +39,7 @@ namespace IntegrationTests
         [Fact]
         public void TestWorkFLow()
         {
-            DateTime now = DateTime.Now;
+            DateTime now = DateTime.UtcNow;
 
             string byteKey = "byteKey";
             string stringKey = "stringKey";

--- a/src/Tests/IntegrationTests/TestKeyValue.cs
+++ b/src/Tests/IntegrationTests/TestKeyValue.cs
@@ -37,9 +37,9 @@ namespace IntegrationTests
         }
 
         [Fact]
-        public void TestWorkFLow()
+        public void TestWorkFlow()
         {
-            DateTime now = DateTime.UtcNow;
+            DateTime utcNow = DateTime.UtcNow;
 
             string byteKey = "byteKey";
             string stringKey = "stringKey";
@@ -117,13 +117,13 @@ namespace IntegrationTests
 
                 // entry gives detail about latest entry of the key
                 byteHistory.Add(
-                    AssertEntry(BUCKET, byteKey, KeyValueOperation.Put, 1, byteValue1, now, kv.Get(byteKey)));
+                    AssertEntry(BUCKET, byteKey, KeyValueOperation.Put, 1, byteValue1, utcNow, kv.Get(byteKey)));
 
                 stringHistory.Add(
-                    AssertEntry(BUCKET, stringKey, KeyValueOperation.Put, 2, stringValue1, now, kv.Get(stringKey)));
+                    AssertEntry(BUCKET, stringKey, KeyValueOperation.Put, 2, stringValue1, utcNow, kv.Get(stringKey)));
 
                 longHistory.Add(
-                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 3, "1", now, kv.Get(longKey)));
+                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 3, "1", utcNow, kv.Get(longKey)));
 
                 // history gives detail about the key
                 AssertHistory(byteHistory, kv.History(byteKey));
@@ -139,7 +139,7 @@ namespace IntegrationTests
                 kv.Delete(byteKey);
 
                 byteHistory.Add(
-                    AssertEntry(BUCKET, byteKey, KeyValueOperation.Delete, 4, null, now, kv.Get(byteKey)));
+                    AssertEntry(BUCKET, byteKey, KeyValueOperation.Delete, 4, null, utcNow, kv.Get(byteKey)));
                 AssertHistory(byteHistory, kv.History(byteKey));
 
                 // let's check the bucket info
@@ -170,15 +170,15 @@ namespace IntegrationTests
 
                 // entry and history after update
                 byteHistory.Add(
-                    AssertEntry(BUCKET, byteKey, KeyValueOperation.Put, 5, byteValue2, now, kv.Get(byteKey)));
+                    AssertEntry(BUCKET, byteKey, KeyValueOperation.Put, 5, byteValue2, utcNow, kv.Get(byteKey)));
                 AssertHistory(byteHistory, kv.History(byteKey));
 
                 stringHistory.Add(
-                    AssertEntry(BUCKET, stringKey, KeyValueOperation.Put, 6, stringValue2, now, kv.Get(stringKey)));
+                    AssertEntry(BUCKET, stringKey, KeyValueOperation.Put, 6, stringValue2, utcNow, kv.Get(stringKey)));
                 AssertHistory(stringHistory, kv.History(stringKey));
 
                 longHistory.Add(
-                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 7, "2", now, kv.Get(longKey)));
+                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 7, "2", utcNow, kv.Get(longKey)));
                 AssertHistory(longHistory, kv.History(longKey));
 
                 // let's check the bucket info
@@ -192,7 +192,7 @@ namespace IntegrationTests
                 Assert.Equal(3, lvalue);
 
                 longHistory.Add(
-                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 8, "3", now, kv.Get(longKey)));
+                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 8, "3", utcNow, kv.Get(longKey)));
                 AssertHistory(longHistory, kv.History(longKey));
 
                 status = kvm.GetBucketInfo(BUCKET);
@@ -208,7 +208,7 @@ namespace IntegrationTests
                 // history only retains 3 records
                 longHistory.RemoveAt(0);
                 longHistory.Add(
-                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 9, "4", now, kv.Get(longKey)));
+                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 9, "4", utcNow, kv.Get(longKey)));
                 AssertHistory(longHistory, kv.History(longKey));
 
                 // record count does not increase
@@ -223,7 +223,7 @@ namespace IntegrationTests
                 kv.Purge(longKey);
                 longHistory.Clear();
                 longHistory.Add(
-                    AssertEntry(BUCKET, longKey, KeyValueOperation.Purge, 10, null, now, kv.Get(longKey)));
+                    AssertEntry(BUCKET, longKey, KeyValueOperation.Purge, 10, null, utcNow, kv.Get(longKey)));
                 AssertHistory(longHistory, kv.History(longKey));
 
                 status = kvm.GetBucketInfo(BUCKET);
@@ -236,7 +236,7 @@ namespace IntegrationTests
                 kv.Purge(byteKey);
                 byteHistory.Clear();
                 byteHistory.Add(
-                    AssertEntry(BUCKET, byteKey, KeyValueOperation.Purge, 11, null, now, kv.Get(byteKey)));
+                    AssertEntry(BUCKET, byteKey, KeyValueOperation.Purge, 11, null, utcNow, kv.Get(byteKey)));
                 AssertHistory(byteHistory, kv.History(byteKey));
 
                 status = kvm.GetBucketInfo(BUCKET);
@@ -249,7 +249,7 @@ namespace IntegrationTests
                 kv.Purge(stringKey);
                 stringHistory.Clear();
                 stringHistory.Add(
-                    AssertEntry(BUCKET, stringKey, KeyValueOperation.Purge, 12, null, now, kv.Get(stringKey)));
+                    AssertEntry(BUCKET, stringKey, KeyValueOperation.Purge, 12, null, utcNow, kv.Get(stringKey)));
                 AssertHistory(stringHistory, kv.History(stringKey));
 
                 status = kvm.GetBucketInfo(BUCKET);
@@ -275,23 +275,23 @@ namespace IntegrationTests
                 // put some more
                 Assert.Equal(13U, kv.Put(longKey, 110));
                 longHistory.Add(
-                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 13, "110", now, kv.Get(longKey)));
+                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 13, "110", utcNow, kv.Get(longKey)));
 
                 Assert.Equal(14U, kv.Put(longKey, 111));
                 longHistory.Add(
-                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 14, "111", now, kv.Get(longKey)));
+                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 14, "111", utcNow, kv.Get(longKey)));
 
                 Assert.Equal(15U, kv.Put(longKey, 112));
                 longHistory.Add(
-                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 15, "112", now, kv.Get(longKey)));
+                    AssertEntry(BUCKET, longKey, KeyValueOperation.Put, 15, "112", utcNow, kv.Get(longKey)));
 
                 Assert.Equal(16U, kv.Put(stringKey, stringValue1));
                 stringHistory.Add(
-                    AssertEntry(BUCKET, stringKey, KeyValueOperation.Put, 16, stringValue1, now, kv.Get(stringKey)));
+                    AssertEntry(BUCKET, stringKey, KeyValueOperation.Put, 16, stringValue1, utcNow, kv.Get(stringKey)));
 
                 Assert.Equal(17U, kv.Put(stringKey, stringValue2));
                 stringHistory.Add(
-                    AssertEntry(BUCKET, stringKey, KeyValueOperation.Put, 17, stringValue2, now, kv.Get(stringKey)));
+                    AssertEntry(BUCKET, stringKey, KeyValueOperation.Put, 17, stringValue2, utcNow, kv.Get(stringKey)));
 
                 AssertHistory(longHistory, kv.History(longKey));
                 AssertHistory(stringHistory, kv.History(stringKey));
@@ -686,7 +686,7 @@ namespace IntegrationTests
             }
         }
 
-        private KeyValueEntry AssertEntry(string bucket, string key, KeyValueOperation op, ulong seq, string value, DateTime now, KeyValueEntry entry) {
+        private KeyValueEntry AssertEntry(string bucket, string key, KeyValueOperation op, ulong seq, string value, DateTime utcNow, KeyValueEntry entry) {
             Assert.Equal(bucket, entry.Bucket);
             Assert.Equal(key, entry.Key);
             Assert.Equal(op, entry.Operation);
@@ -697,7 +697,7 @@ namespace IntegrationTests
             else {
                 Assert.Null(entry.Value);
             }
-            Assert.True(now.CompareTo(entry.Created) < 0);
+            Assert.True(utcNow.CompareTo(entry.Created.ToUniversalTime()) < 0);
             return entry;
         }
 

--- a/src/Tests/UnitTests/JetStream/TestConsumerConfiguration.cs
+++ b/src/Tests/UnitTests/JetStream/TestConsumerConfiguration.cs
@@ -247,7 +247,7 @@ namespace UnitTests.JetStream
             AssertNotChange(ccTest, ccTest);
             AssertChange(ccTest, orig, "FlowControl", "IdleHeartbeat");
 
-            ccTest = Builder(orig).WithStartTime(DateTime.Now).Build();
+            ccTest = Builder(orig).WithStartTime(DateTime.UtcNow).Build();
             AssertNotChange(ccTest, ccTest);
             AssertChange(ccTest, orig, "StartTime");
 

--- a/src/Tests/UnitTests/JetStream/TestStreamConfiguration.cs
+++ b/src/Tests/UnitTests/JetStream/TestStreamConfiguration.cs
@@ -286,7 +286,7 @@ namespace UnitTests.JetStream
         [Fact]
         public void TestSource()
         {
-            DateTime now = DateTime.Now;
+            DateTime now = DateTime.UtcNow;
             Source s = new Source("name1", 1, now, "fs1", new External("api1", "deliver1"));
             Assert.Equal("name1", s.Name);
             Assert.Equal(1U, s.StartSeq);
@@ -295,7 +295,7 @@ namespace UnitTests.JetStream
             Assert.Equal("api1", s.External.Api);
             Assert.Equal("deliver1", s.External.Deliver);
             
-            now = DateTime.Now;
+            now = DateTime.UtcNow;
             s = Source.Builder()
                 .WithName("name2")
                 .WithStartSeq(2)
@@ -318,7 +318,7 @@ namespace UnitTests.JetStream
         [Fact]
         public void TestMirror()
         {
-            DateTime now = DateTime.Now;
+            DateTime now = DateTime.UtcNow;
             Mirror m = new Mirror("name1", 1, now, "fs1", new External("api1", "deliver1"));
             Assert.Equal("name1", m.Name);
             Assert.Equal(1U, m.StartSeq);
@@ -327,7 +327,7 @@ namespace UnitTests.JetStream
             Assert.Equal("api1", m.External.Api);
             Assert.Equal("deliver1", m.External.Deliver);
             
-            now = DateTime.Now;
+            now = DateTime.UtcNow;
             m = Mirror.Builder()
                 .WithName("name2")
                 .WithStartSeq(2)


### PR DESCRIPTION
Noticed a few of the integration tests failed when ran locally and decided to fix them.
The issue was that local timestamps were being compared with utc timestamps.
In .NET the DateTimeKind is not checked when comparing, so we must make sure these are the same.