### PR TITLE
docs: fix wrong class name for Nkeys in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ EventHandler<UserSignatureEventArgs> sigEh = (sender, args) =>
     string seed = getMyUserSeed();
 
     // Generate a NkeyPair
-    NkeyPair kp = NKeys.FromSeed(seed);
+    NkeyPair kp = Nkeys.FromSeed(seed);
 
     // Sign the nonce and return the result in the SignedNonce
     // args property.  This must be set.


### PR DESCRIPTION
This PR fixes an incorrect use of https://github.com/nats-io/nats.net/blob/cd3c71b768d4b120bdae8661b0ae2ba12f24562d/src/NATS.Client/NKeys.cs#L156 

Might be the other way around and it's the class that needs to be renamed, but I leave that up to you 😄 