### PR TITLE
Fixed TcpClient not disposed when an exception is thrown during connect

### DIFF
--- a/src/NATS.Client/Conn.cs
+++ b/src/NATS.Client/Conn.cs
@@ -384,7 +384,11 @@ namespace NATS.Client
 
                     var task = client.ConnectAsync(s.Url.Host, s.Url.Port);
                     // avoid raising TaskScheduler.UnobservedTaskException if the timeout occurs first
-                    task.ContinueWith(t => GC.KeepAlive(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+                    task.ContinueWith(t => 
+                    {
+                        GC.KeepAlive(t.Exception);
+                        close(client);
+                    }, TaskContinuationOptions.OnlyOnFaulted);
                     if (!task.Wait(TimeSpan.FromMilliseconds(timeoutMillis)))
                     {
                         close(client);


### PR DESCRIPTION
When an exception occurred during the ConnectAsync (i.e. socketException), the TcpClient would not be closed. In certain situations where the reconnect keeps failing with an exception this would result in an increase in handles as the ~TcpClient() does not clean up managed resources such as sockets.