### PR TITLE
Update_the_default_SubscriberDeliveryTaskCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ Please see unit test for examples of this behavior.
 `TestMaxPayload` in [TestBasic](src/Tests/IntegrationTests/TestBasic.cs)
 and
 `TestMaxPayloadJs` in [TestJetStream](src/Tests/IntegrationTests/TestJetStream.cs)
+### Version 1.0.? Subscriber Delivery Task Count
+
+The default value of this option was changed from 0 to 3. 
+Zero means each subscriber has it's own delivery task.
+Setting it to zero where each subscriber has a delivery task is very 
+performant, but does not scale well when large numbers of
+subscribers are required in an application. Setting this value
+will limit the number of subscriber channels to the specified number
+of long running tasks. These tasks will process messages for ALL
+asynchronous subscribers rather than one task for each subscriber.  
+Delivery order by subscriber is still guaranteed. The shared message
+processing channels are still each bounded by the SubChannelLength 
+option.  Note, slow subscriber errors will flag the last subscriber 
+processed in the tasks, which may not actually be the slowest subscriber.
 
 ### Version 1.0.1 Consumer Create
 

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -245,7 +245,7 @@ namespace NATS.Client
         internal int maxPingsOut = MaxPingOut;
 
         internal int subChanLen = (int)SubPendingMsgsLimit;
-        internal int subscriberDeliveryTaskCount = 0;
+        internal int subscriberDeliveryTaskCount = 1;
 
         // Must be greater than 0.
         internal int subscriptionBatchSize = 64;
@@ -644,12 +644,13 @@ namespace NATS.Client
 
         /// <summary>
         /// Gets or sets the number of long running tasks to deliver messages
-        /// to asynchronous subscribers. The default is zero (<c>0</c>) indicating each
+        /// to asynchronous subscribers. default is set to one (<c>0</c>).
+        /// Setting it to zero (<c>0</c>) makes each
         /// asynchronous subscriber has its own channel and task created to 
         /// deliver messages.
         /// </summary>
         /// <remarks>
-        /// The default where each subscriber has a delivery task is very 
+        /// Setting it to zero where each subscriber has a delivery task is very 
         /// performant, but does not scale well when large numbers of
         /// subscribers are required in an application.  Setting this value
         /// will limit the number of subscriber channels to the specified number

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -644,7 +644,7 @@ namespace NATS.Client
 
         /// <summary>
         /// Gets or sets the number of long running tasks to deliver messages
-        /// to asynchronous subscribers. default is set to one (<c>0</c>).
+        /// to asynchronous subscribers. default is set to one (<c>1</c>).
         /// Setting it to zero (<c>0</c>) makes each
         /// asynchronous subscriber has its own channel and task created to 
         /// deliver messages.

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -646,7 +646,7 @@ namespace NATS.Client
         /// Gets or sets the number of long running tasks to deliver messages
         /// to asynchronous subscribers. default is set to one (<c>1</c>).
         /// Setting it to zero (<c>0</c>) makes each
-        /// asynchronous subscriber has its own channel and task created to 
+        /// asynchronous subscriber have its own channel and task created to 
         /// deliver messages.
         /// </summary>
         /// <remarks>

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -245,7 +245,7 @@ namespace NATS.Client
         internal int maxPingsOut = MaxPingOut;
 
         internal int subChanLen = (int)SubPendingMsgsLimit;
-        internal int subscriberDeliveryTaskCount = 1;
+        internal int subscriberDeliveryTaskCount = 3;
 
         // Must be greater than 0.
         internal int subscriptionBatchSize = 64;

--- a/src/Tests/IntegrationTests/TestSubscriptions.cs
+++ b/src/Tests/IntegrationTests/TestSubscriptions.cs
@@ -1017,7 +1017,7 @@ namespace IntegrationTests
         {
             var SUBSCOUNT = 10000;
             var MSGSCOUNT = 100;
-            var TIMETOGETMSGS = 1000;
+            var TIMETOGETMSGS = 2000;
                 
             var opts = Context.GetTestOptions(Context.Server1.Port);
             

--- a/src/Tests/IntegrationTests/TestSubscriptions.cs
+++ b/src/Tests/IntegrationTests/TestSubscriptions.cs
@@ -1017,7 +1017,7 @@ namespace IntegrationTests
         {
             var SUBSCOUNT = 10000;
             var MSGSCOUNT = 100;
-            var TIMETOGETMSGS = 2000;
+            var TIMETOGETMSGS = 5000;
                 
             var opts = Context.GetTestOptions(Context.Server1.Port);
             


### PR DESCRIPTION
This pull request is meant to solve this issue https://github.com/nats-io/nats.net/issues/450. 
The added test was tried against different numbers of `SubscriberDeliveryTaskCount`, it takes around ~500 ms to process, leaving it to 0 (as was the default before) takes more than 1000 ms ( ~7000ms).