### PR TITLE
Enable custom TCPConnection implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,27 @@ The NATS server default cipher suites **may not be supported** by the Microsoft
 the  NATS server to include the most secure cipher suites supported by the
 .NET framework.
 
+## Custom Dialer/Custom TCP connection. 
+
+The NATs .NET client supports passing in a custom implementation of the [ITCPConnection](TCPConnCustom/src/NATS.Client/ITCPConnection.cs) class.
+
+```c#
+	public class TCPConnection : ITCPConnection
+    {
+        <Custom implementation of ITCPConnection>
+    }
+
+	<...>
+		Options opts = ConnectionFactory.GetDefaultOptions();
+        opts.TCPConnection = new CustomTCPConnection();
+
+        IConnection c = new ConnectionFactory().CreateConnection(opts);
+```
+
+This is useful for testing, or implementing a TCPConnection that supports TLS termination.
+
+See [TLSReverseProxyExample](src\Samples\TLSReverseProxyExample) for an implementation. 
+
 ## NATS 2.0 Authentication (Nkeys and User Credentials)
 
 This requires server with version >= 2.0.0

--- a/src/NATS.Client/ITCPConnection.cs
+++ b/src/NATS.Client/ITCPConnection.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace NATS.Client
+{
+    public interface ITCPConnection : IDisposable 
+    {
+        bool Connected { get; }
+        bool DataAvailable { get; }
+        int SendTimeout { set; }
+        int ReceiveTimeout { get; set; }
+        void open(Srv s, Options options);
+        void close(TcpClient c);
+        void makeTLS();
+        bool isSetup();
+        void teardown();
+        Stream getReadBufferedStream();
+        Stream getWriteBufferedStream(int size);
+
+    }
+}

--- a/src/NATS.Client/NATS.cs
+++ b/src/NATS.Client/NATS.cs
@@ -163,7 +163,7 @@ namespace NATS.Client
         internal const int MaxControlLineSize = 4096;
 
         // The size of the bufio writer on top of the socket.
-        internal const int defaultBufSize = 32768;
+        public const int defaultBufSize = 32768;
 
         // The read size from the network stream.
         internal const int defaultReadLength = 20480;

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -44,6 +44,7 @@ namespace NATS.Client
         int timeout       = Defaults.Timeout;
         int reconnectJitter = Defaults.ReconnectJitter;
         int reconnectJitterTLS = Defaults.ReconnectJitterTLS;
+        ITCPConnection tcpConnection = null;
 
         internal X509Certificate2Collection certificates = null;
 
@@ -303,6 +304,7 @@ namespace NATS.Client
             subscriberDeliveryTaskCount = o.subscriberDeliveryTaskCount;
             subscriptionBatchSize = o.subscriptionBatchSize;
             customInboxPrefix = o.customInboxPrefix;
+            tcpConnection = o.TCPConnection;
 
             url = o.url;
             if (o.servers != null)
@@ -459,6 +461,15 @@ namespace NATS.Client
             set { secure = value; }
         }
 
+        /// <summary>
+        /// Get or sets a custom ITCPConnection object to use for communication
+        /// to the NATs Server.
+        /// </summary>
+        public ITCPConnection TCPConnection
+        {
+            get { return tcpConnection; }
+            set { tcpConnection = value; }
+        }
         /// <summary>
         /// Gets or sets a value indicating whether or not an <see cref="IConnection"/> will attempt
         /// to reconnect to the NATS server if a connection has been lost.

--- a/src/NATS.sln
+++ b/src/NATS.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29230.47
@@ -116,6 +116,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JetStreamPushSubscribeAsyncQueueDurable", "Samples\JetStreamPushSubscribeAsyncQueueDurable\JetStreamPushSubscribeAsyncQueueDurable.csproj", "{5DCD0666-5AC9-462F-99BD-5E8E95E4B749}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimplificationQueue", "Samples\SimplificationQueue\SimplificationQueue.csproj", "{F8609197-D5B0-42CC-890E-921CAAA1589E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLSReverseProxyExample", "Samples\TLSReverseProxyExample\TLSReverseProxyExample.csproj", "{98C52074-7693-48D4-B0A9-48920EEEDA24}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -377,6 +379,7 @@ Global
 		{C7FB00D4-23F1-4F6A-A8C0-E58346F272DE} = {776C2E80-958B-4C0D-BCC4-67D39DB4570B}
 		{5DCD0666-5AC9-462F-99BD-5E8E95E4B749} = {776C2E80-958B-4C0D-BCC4-67D39DB4570B}
 		{F8609197-D5B0-42CC-890E-921CAAA1589E} = {776C2E80-958B-4C0D-BCC4-67D39DB4570B}
+		{98C52074-7693-48D4-B0A9-48920EEEDA24} = {776C2E80-958B-4C0D-BCC4-67D39DB4570B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0972F03C-E4DF-483A-B767-9216F4434F11}

--- a/src/Samples/TLSReverseProxyExample/CustomTCPConnection.cs
+++ b/src/Samples/TLSReverseProxyExample/CustomTCPConnection.cs
@@ -1,0 +1,33 @@
+﻿using NATS.Client;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Runtime.InteropServices.ComTypes;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using static NATS.Client.Defaults;
+
+
+namespace NATSExamples
+{
+
+
+        /// <summary>
+        /// Convenience class representing the TCP connection to prevent 
+        /// managing two variables throughout the NATs client code.
+        /// 
+        /// This "Custom" implementation just makes the connection TLS after opening it. 
+        /// </summary>
+        public class CustomTCPConnection : Connection.TCPConnection
+        {
+
+            public override void open(Srv s, Options options)
+            {
+                base.open(s, options);
+                base.makeTLS();
+            } 
+        }
+    }
+

--- a/src/Samples/TLSReverseProxyExample/TLSReverseProxyExample.cs
+++ b/src/Samples/TLSReverseProxyExample/TLSReverseProxyExample.cs
@@ -1,0 +1,52 @@
+﻿using NATS.Client;
+using System;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace NATSExamples
+{
+    /// <summary>
+    /// This example shows how to use a TLS-Terminating proxy with the NATs .NET client
+    /// 
+    /// This example is not production hardened
+    /// 
+    /// You can create a TLS Terminating proxy using Stunnel. 
+    /// 
+    /// </summary>
+    internal static class TlsVariationsExample
+    {
+        // 8444 is a port where the Terminating Proxy is listening
+        static readonly string Url = "nats://192.168.1.108:8444";
+        // This is unsafe and assumes all certificates are good. 
+        private static bool verifyServerCert(object sender,
+            X509Certificate certificate, X509Chain chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            return true;
+            
+        }
+
+        public static void Main(string[] args)
+        {
+
+            var opts = ConnectionFactory.GetDefaultOptions();
+            opts.Url = Url;
+            opts.TLSRemoteCertificationValidationCallback = verifyServerCert;
+            opts.TCPConnection = new CustomTCPConnection();
+
+            try
+            {
+                using (IConnection c = new ConnectionFactory().CreateConnection(opts))
+                {
+
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex);
+            }
+        }
+    }
+}
+
+

--- a/src/Samples/TLSReverseProxyExample/TLSReverseProxyExample.csproj
+++ b/src/Samples/TLSReverseProxyExample/TLSReverseProxyExample.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Title>NATS TLS Terminating Proxy Example</Title>
+    <Description>NATS TLS Terminating Proxy Example</Description>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>NATSExamples</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\NATS.Client\NATS.Client.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
+  </PropertyGroup>
+</Project>
+


### PR DESCRIPTION
This PR expands on the TCPConnection class to be an interface that can be overridden with a options argument to supply a custom interface for implementing the connection class used by the nats client. 

The changes here are modeled after how the Java client handles a custom dialer. 

I included an example of my use case here which is enabling a TLS Reverse proxy to terminate the TLS connection by performing the SSL upgrade before nats communication starts. 