### PR TITLE
[BUG] Missed inheriting code caused failure

### DIFF
--- a/src/NATS.Client/JetStream/JetStreamPushAsyncSubscription.cs
+++ b/src/NATS.Client/JetStream/JetStreamPushAsyncSubscription.cs
@@ -13,49 +13,12 @@
 
 namespace NATS.Client.JetStream
 {
-    public class JetStreamPushAsyncSubscription : AsyncSubscription, IJetStreamPushAsyncSubscription
+    public class JetStreamPushAsyncSubscription : JetStreamAbstractAsyncSubscription, IJetStreamPushAsyncSubscription
     {
-        internal readonly MessageManager messageManager;
-        internal string _consumer;
-
-        // properties of IJetStreamSubscription
-        public JetStream Context { get; }
-        public string Stream { get; }
-        public string Consumer => _consumer;
-        public string DeliverSubject { get; }
-
         internal JetStreamPushAsyncSubscription(Connection conn, string subject, string queue,
             JetStream js, string stream, string consumer, string deliver, MessageManager messageManager)
-            : base(conn, subject, queue)
-        {
-            Context = js;
-            Stream = stream;
-            _consumer = consumer; // might be null, JetStream will call UpdateConsumer later
-            DeliverSubject = deliver;
-
-            this.messageManager = messageManager;
-            messageManager.Startup(this);
-        }
-
-        internal void UpdateConsumer(string consumer)
-        {
-            _consumer = consumer;
-        }
-
-        public ConsumerInfo GetConsumerInformation() => Context.LookupConsumerInfo(Stream, Consumer);
-
+            : base(conn, subject, queue, js, stream, consumer, deliver, messageManager) {}
+        
         public bool IsPullMode() => false;
-
-        public override void Unsubscribe()
-        {
-            messageManager.Shutdown();
-            base.Unsubscribe();
-        }
-
-        internal override void close()
-        {
-            messageManager.Shutdown();
-            base.close();
-        }
     }
 }

--- a/src/Tests/IntegrationTests/TestJetStream.cs
+++ b/src/Tests/IntegrationTests/TestJetStream.cs
@@ -941,10 +941,11 @@ namespace IntegrationTests
             
             Options opts = ConnectionFactory.GetDefaultOptions();
             opts.AllowReconnect = false;
+            opts.Url = $"nats://127.0.0.1:{Context.Server1.Port}";
             NATSServer.QuietOptionsModifier.Invoke(opts);
 
             ulong expectedSeq = 0;
-            using (NATSServer.CreateJetStreamFast())
+            using (NATSServer.CreateJetStreamFast(Context.Server1.Port))
             {
                 using (var c = Context.ConnectionFactory.CreateConnection(opts))
                 {

--- a/src/Tests/IntegrationTests/TestKeyValue.cs
+++ b/src/Tests/IntegrationTests/TestKeyValue.cs
@@ -21,7 +21,6 @@ using NATS.Client.Internals;
 using NATS.Client.JetStream;
 using NATS.Client.KeyValue;
 using Xunit;
-using Xunit.Abstractions;
 using static UnitTests.TestBase;
 using static IntegrationTests.JetStreamTestBase;
 using static NATS.Client.JetStream.JetStreamOptions;
@@ -31,13 +30,7 @@ namespace IntegrationTests
 {
     public class TestKeyValue : TestSuite<KeyValueSuiteContext>
     {
-        private readonly ITestOutputHelper output;
-
-        public TestKeyValue(ITestOutputHelper output, KeyValueSuiteContext context) : base(context)
-        {
-            this.output = output;
-            Console.SetOut(new ConsoleWriter(output));
-        }
+        public TestKeyValue(KeyValueSuiteContext context) : base(context) {}
 
         [Fact]
         public void TestWorkFlow()


### PR DESCRIPTION
When refactoring pull sync subscription class to have shared base abstract code in common with the push subscription, the push sync subscription class was copied to the abstract class, but was not changed to inherit from it. This caused calls to `sub.GetConsumerInfo` to fail, since it didn't properly have the consumer name.
This affects all Push subscriptions if the dev calls `sub.GetConsumerInfo`, thankfully that's fairly uncommon. But...KeyValue watches use push under the covers and immediately call `sub.GetConsumerInfo`, so immediately fail.
Sigh. Sorry. It's fixed now. I'll release 1.0.7 as soon as possible.