### PR TITLE
Fix use of JsOptions timeout

### DIFF
--- a/src/NATS.Client/JetStream/JetStream.cs
+++ b/src/NATS.Client/JetStream/JetStream.cs
@@ -86,9 +86,7 @@ namespace NATS.Client.JetStream
                 return null;
             }
             
-            Duration timeout = options == null ? JetStreamOptions.RequestTimeout : options.StreamTimeout;
-            
-            return ProcessPublishResponse(Conn.Request(msg, timeout.Millis), options);
+            return ProcessPublishResponse(Conn.Request(msg, Timeout), options);
         }
 
         private async Task<PublishAck> PublishAsyncInternal(string subject, byte[] data, MsgHeader hdr, PublishOptions options)
@@ -102,9 +100,7 @@ namespace NATS.Client.JetStream
                 return null;
             }
 
-            Duration timeout = options == null ? JetStreamOptions.RequestTimeout : options.StreamTimeout;
-
-            var result = await Conn.RequestAsync(msg, timeout.Millis).ConfigureAwait(false);
+            var result = await Conn.RequestAsync(msg, Timeout).ConfigureAwait(false);
             return ProcessPublishResponse(result, options);
         }
 

--- a/src/NATS.Client/JetStream/JetStreamBase.cs
+++ b/src/NATS.Client/JetStream/JetStreamBase.cs
@@ -44,7 +44,7 @@ namespace NATS.Client.JetStream
             Conn = connection;
             JetStreamOptions = options ?? JetStreamOptions.DefaultJsOptions;
             Prefix = JetStreamOptions.Prefix;
-            Timeout = JetStreamOptions.RequestTimeout.Millis;
+            Timeout = JetStreamOptions.RequestTimeout == null ? Conn.Opts.Timeout : JetStreamOptions.RequestTimeout.Millis;
         }
 
         internal static ServerInfo ServerInfoOrException(IConnection conn)

--- a/src/NATS.Client/JetStream/JetStreamBase.cs
+++ b/src/NATS.Client/JetStream/JetStreamBase.cs
@@ -44,7 +44,7 @@ namespace NATS.Client.JetStream
             Conn = connection;
             JetStreamOptions = options ?? JetStreamOptions.DefaultJsOptions;
             Prefix = JetStreamOptions.Prefix;
-            Timeout = JetStreamOptions.RequestTimeout == null ? Conn.Opts.Timeout : JetStreamOptions.RequestTimeout.Millis;
+            Timeout = JetStreamOptions.RequestTimeout?.Millis ?? Conn.Opts.Timeout;
         }
 
         internal static ServerInfo ServerInfoOrException(IConnection conn)

--- a/src/NATS.Client/JetStream/JetStreamOptions.cs
+++ b/src/NATS.Client/JetStream/JetStreamOptions.cs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using NATS.Client.Internals;
 using static NATS.Client.Internals.JetStreamConstants;
 using static NATS.Client.Internals.NatsConstants;
@@ -20,7 +21,9 @@ namespace NATS.Client.JetStream
 {
     public sealed class JetStreamOptions
     {
+        [Obsolete("This property is obsolete. The connection options request timeout is used as the default", false)]
         public static readonly Duration DefaultTimeout = Duration.OfMillis(Defaults.Timeout);
+        
         public static readonly JetStreamOptions DefaultJsOptions = Builder().Build();
 
         private JetStreamOptions(JetStreamOptionsBuilder b)
@@ -94,7 +97,7 @@ namespace NATS.Client.JetStream
         public sealed class JetStreamOptionsBuilder
         {
             internal string _jsPrefix;
-            internal Duration _requestTimeout = DefaultTimeout;
+            internal Duration _requestTimeout;
             internal bool _publishNoAck;
             internal bool _optOut290ConsumerCreate;
 
@@ -160,7 +163,7 @@ namespace NATS.Client.JetStream
             /// <returns>The JetStreamOptionsBuilder</returns>
             public JetStreamOptionsBuilder WithRequestTimeout(Duration requestTimeout)
             {
-                _requestTimeout = EnsureNotNullAndNotLessThanMin(requestTimeout, Duration.Zero, DefaultTimeout);
+                _requestTimeout = requestTimeout;
                 return this;
             }
 
@@ -169,9 +172,9 @@ namespace NATS.Client.JetStream
             /// </summary>
             /// <param name="requestTimeoutMillis">The request timeout in millis.</param>
             /// <returns>The JetStreamOptionsBuilder</returns>
-            public JetStreamOptionsBuilder WithRequestTimeout(long requestTimeoutMillis) 
+            public JetStreamOptionsBuilder WithRequestTimeout(long requestTimeoutMillis)
             {
-                _requestTimeout = EnsureDurationNotLessThanMin(requestTimeoutMillis, Duration.Zero, DefaultTimeout);
+                _requestTimeout = requestTimeoutMillis < 0 ? null : Duration.OfMillis(requestTimeoutMillis);
                 return this;
             }
 
@@ -201,7 +204,6 @@ namespace NATS.Client.JetStream
             /// <returns>The JetStreamOptions object.</returns>
             public JetStreamOptions Build()
             {
-                _requestTimeout = _requestTimeout ?? DefaultTimeout;
                 return new JetStreamOptions(this);
             }
         }

--- a/src/Tests/IntegrationTests/TestObjectStore.cs
+++ b/src/Tests/IntegrationTests/TestObjectStore.cs
@@ -319,7 +319,7 @@ namespace IntegrationTests
 
         private void AssertOso(ObjectStoreOptions oso) {
             JetStreamOptions jso = oso.JSOptions;
-            Assert.Equal(DefaultJsOptions.RequestTimeout, jso.RequestTimeout);
+            Assert.Null(jso.RequestTimeout);
             Assert.Equal(DefaultJsOptions.Prefix, jso.Prefix);
             Assert.Equal(DefaultJsOptions.IsDefaultPrefix, jso.IsDefaultPrefix);
             Assert.Equal(DefaultJsOptions.IsPublishNoAck, jso.IsPublishNoAck);

--- a/src/Tests/UnitTests/JetStream/TestJetStreamOptions.cs
+++ b/src/Tests/UnitTests/JetStream/TestJetStreamOptions.cs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 using System;
-using NATS.Client;
 using NATS.Client.Internals;
 using NATS.Client.JetStream;
 using Xunit;
@@ -27,7 +26,7 @@ namespace UnitTests.JetStream
         {
             // default
             JetStreamOptions jso = JetStreamOptions.Builder().Build();
-            Assert.Equal(Duration.OfMillis(Defaults.Timeout), jso.RequestTimeout);
+            Assert.Null(jso.RequestTimeout);
             Assert.Equal(DefaultApiPrefix, jso.Prefix);
             Assert.True(jso.IsDefaultPrefix);
             Assert.False(jso.IsPublishNoAck);
@@ -35,7 +34,7 @@ namespace UnitTests.JetStream
 
             // default copy
             jso = JetStreamOptions.Builder(jso).Build();
-            Assert.Equal(Duration.OfMillis(Defaults.Timeout), jso.RequestTimeout);
+            Assert.Null(jso.RequestTimeout);
             Assert.Equal(DefaultApiPrefix, jso.Prefix);
             Assert.True(jso.IsDefaultPrefix);
             Assert.False(jso.IsPublishNoAck);


### PR DESCRIPTION
When making requests from JetStream classes, the JetStreamOptions. There was use of the Connection options timeout instead in one place and this was fixed. Also, the default JetStreamOption timeout was resolved to the connection timeout if the JetStreamOption timeout was not explicitly set.