### PR TITLE
Expose pending limits in the Options

### DIFF
--- a/src/Benchmarks/Benchmark/Benchmark.cs
+++ b/src/Benchmarks/Benchmark/Benchmark.cs
@@ -197,7 +197,7 @@ namespace Benchmark
             Options o = ConnectionFactory.GetDefaultOptions();
             
             o.Url = url;
-            o.SubChannelLength = 10000000;
+            o.PendingMessageLimit = 10000000;
             if (creds != null)
             {
                 o.SetUserCredentials(creds);

--- a/src/NATS.Client/Connection.cs
+++ b/src/NATS.Client/Connection.cs
@@ -4215,7 +4215,7 @@ namespace NATS.Client
                     createAsyncSubscriptionDelegate = (lConn, lSubject, lQueue) =>
                     {
                         AsyncSubscription asub = new AsyncSubscription(lConn, lSubject, lQueue);
-                        asub.SetPendingLimits(opts.subChanLen, SubPendingBytesLimit);
+                        asub.SetPendingLimits(opts.PendingMessageLimit, opts.PendingBytesLimit);
                         return asub;
                     };
                 }
@@ -4261,7 +4261,7 @@ namespace NATS.Client
                     syncSubDelegate = (lConn, lSubject, lQueue) =>
                     {
                         SyncSubscription ssub = new SyncSubscription(this, subject, queue);
-                        ssub.SetPendingLimits(opts.subChanLen, SubPendingBytesLimit);
+                        ssub.SetPendingLimits(opts.PendingMessageLimit, opts.PendingBytesLimit);
                         return ssub;
                     };
                 }

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -557,9 +557,9 @@ namespace NATS.Client
         /// Gets or sets the size of the subscriber channel, or number
         /// of messages the subscriber will buffer internally.
         /// </summary>
+        [Obsolete("Please use the PendingMessageLimit property instead")]
         public int SubChannelLength
         {
-            //Property may be obsoleted.
             get { return (int)PendingMessageLimit; }
             set { PendingMessageLimit = value; }
         }
@@ -916,7 +916,6 @@ namespace NATS.Client
                 }
                 sb.Append("};");
             }
-            sb.AppendFormat("SubChannelLength={0};", SubChannelLength);
             sb.AppendFormat($"{nameof(PendingMessageLimit)}={PendingMessageLimit};");
             sb.AppendFormat($"{nameof(PendingBytesLimit)}={PendingBytesLimit};");
             sb.AppendFormat("Timeout={0}", Timeout);

--- a/src/NATS.Client/Options.cs
+++ b/src/NATS.Client/Options.cs
@@ -246,7 +246,8 @@ namespace NATS.Client
 
         internal int maxPingsOut = MaxPingOut;
 
-        internal int subChanLen = (int)SubPendingMsgsLimit;
+        private long pendingMessageLimit = SubPendingMsgsLimit;
+        private long pendingBytesLimit = SubPendingBytesLimit;
         internal int subscriberDeliveryTaskCount = 0;
 
         // Must be greater than 0.
@@ -316,7 +317,8 @@ namespace NATS.Client
                 Array.Copy(o.servers, servers, o.servers.Length);
             }
 
-            subChanLen = o.subChanLen;
+            pendingMessageLimit = o.pendingMessageLimit;
+            pendingBytesLimit = o.pendingBytesLimit;
             timeout = o.timeout;
             TLSRemoteCertificationValidationCallback = o.TLSRemoteCertificationValidationCallback;
 
@@ -557,8 +559,29 @@ namespace NATS.Client
         /// </summary>
         public int SubChannelLength
         {
-            get { return subChanLen; }
-            set { subChanLen = value; }
+            //Property may be obsoleted.
+            get { return (int)PendingMessageLimit; }
+            set { PendingMessageLimit = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the subscriber channel, or number
+        /// of messages the subscriber will buffer internally.
+        /// </summary>
+        public long PendingMessageLimit
+        {
+            get { return pendingMessageLimit; }
+            set { pendingMessageLimit = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum pending bytes limit for the subscription, 
+        /// or number of bytes the subscriber will buffer internally.
+        /// </summary>
+        public long PendingBytesLimit
+        {
+            get { return pendingBytesLimit; }
+            set { pendingBytesLimit = value; }
         }
 
         /// <summary>
@@ -894,6 +917,8 @@ namespace NATS.Client
                 sb.Append("};");
             }
             sb.AppendFormat("SubChannelLength={0};", SubChannelLength);
+            sb.AppendFormat($"{nameof(PendingMessageLimit)}={PendingMessageLimit};");
+            sb.AppendFormat($"{nameof(PendingBytesLimit)}={PendingBytesLimit};");
             sb.AppendFormat("Timeout={0}", Timeout);
             sb.Append("}");
 

--- a/src/NATS.Client/Subscription.cs
+++ b/src/NATS.Client/Subscription.cs
@@ -57,7 +57,7 @@ namespace NATS.Client
         internal long pendingMessagesMax = 0;
         internal long pendingBytesMax = 0;
         internal long pendingMessagesLimit; // getting this from the options
-        internal long pendingBytesLimit = Defaults.SubPendingBytesLimit;
+        internal long pendingBytesLimit; // getting this from the options
         internal long dropped = 0;
 
         // Subject that represents this subscription. This can be different
@@ -87,7 +87,8 @@ namespace NATS.Client
             this.subject = subject;
             this.queue = queue;
 
-            pendingMessagesLimit = conn.Opts.subChanLen;
+            pendingMessagesLimit = conn.Opts.PendingMessageLimit;
+            pendingBytesLimit = conn.Opts.PendingBytesLimit;
             
             sid = SidGenerator.Next();
 

--- a/src/Tests/IntegrationTests/TestConnection.cs
+++ b/src/Tests/IntegrationTests/TestConnection.cs
@@ -359,7 +359,7 @@ namespace IntegrationTests
                 o.ReconnectWait = 500;
                 o.NoRandomize = true;
                 o.Servers = new[] { Context.Server2.Url, Context.Server1.Url };
-                o.SubChannelLength = 1;
+                o.PendingMessageLimit= 1;
 
                 using (IConnection
                     nc = Context.ConnectionFactory.CreateConnection(o),


### PR DESCRIPTION
Had a use case where I wanted to configure these on a connection-based level and noticed these options were not exposed yet.
In theory, Options.SubChannelLength can be obsoleted now, but might want to keep it for backwards compatibility