### PR TITLE
Readme notes for Subject Validation change in 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ The 1.1.0 release has support for Server 2.10 features including:
 * Multiple Filter Subjects
 * Subject Validation
 
+#### Note regarding Subject Validation
+
+With the upgrade to 1.1.1, applications may start throwing exceptions when subscribing to streams: 
+
+```text
+90011 Subject does not match consumer configuration filter
+```
+
+Let's say you have a stream subject `foo.>` And you are subscribing to `foo.a`. 
+When you don't supply a filter subject on a consumer, it becomes `>`, which means all subjects.
+
+So this is a problem, because you think you are subscribing to `foo.a` but in reality, without this check, 
+you will be getting all messages subjects you do not want. 
+Validating the subscribe subject against the filter subject is needed to prevent this.
+Unfortunately, this makes existing code throw the `90011` exception.
+
 ### Version 1.0.8 Simplification and Service Framework
 
 #### Simplification


### PR DESCRIPTION
#### Note regarding Subject Validation

With the upgrade to 1.1.1, applications may start throwing exceptions when subscribing to streams: 

```text
90011 Subject does not match consumer configuration filter
```

Let's say you have a stream subject `foo.>` And you are subscribing to `foo.a`. 
When you don't supply a filter subject on a consumer, it becomes `>`, which means all subjects.

So this is a problem, because you think you are subscribing to `foo.a` but in reality, without this check, 
you will be getting all messages subjects you do not want. 
Validating the subscribe subject against the filter subject is needed to prevent this.
Unfortunately, this makes existing code throw the `90011` exception.
