### PR TITLE
Reconnect on connect, set state

### DIFF
--- a/src/NATS.Client/Connection.cs
+++ b/src/NATS.Client/Connection.cs
@@ -1250,7 +1250,7 @@ namespace NATS.Client
                 {
                     if (reconnectOnConnect)
                     {
-                        status = ConnState.DISCONNECTED; // should be CLOSED, but reconnect works when disconnected
+                        status = ConnState.DISCONNECTED; // comes in as CLOSED, but reconnect doesn't work when closed
                         doReconnect();
                     }
                     else

--- a/src/NATS.Client/Connection.cs
+++ b/src/NATS.Client/Connection.cs
@@ -1250,6 +1250,7 @@ namespace NATS.Client
                 {
                     if (reconnectOnConnect)
                     {
+                        status = ConnState.DISCONNECTED; // should be CLOSED, but reconnect works when disconnected
                         doReconnect();
                     }
                     else


### PR DESCRIPTION
The reconnect loop exits early when status is closed. The first connect sets status to close when it can't connect, so reconnect exited early.
The fix is that before going to reconnect, change the status to disconnected, like it would be if it had been connected then wasn't.