### PR TITLE
Improve parseError message to include position and UTF8 buffer string

### DIFF
--- a/src/NATS.Client/Parser.cs
+++ b/src/NATS.Client/Parser.cs
@@ -13,6 +13,7 @@
 
 using System;
 using System.IO;
+using System.Text;
      
 namespace NATS.Client
 {
@@ -91,7 +92,7 @@ namespace NATS.Client
 
         private void parseError(byte[] buffer, int position)
         {
-            throw new NATSException(string.Format("Parse Error [{0}], {1}", state, buffer));
+            throw new NATSException(string.Format("Parse Error at position {0} [{1}] {2}", position, state, Encoding.UTF8.GetString(buffer)));
         }
 
         internal void parse(byte[] buffer, int len)


### PR DESCRIPTION
`byte[]`'s `ToString` prints `System.Byte[]`. This is not helpful when diagnosing the state of the parser when an error occurs, so I instead print the UTF8 encoded string version of the buffer. I also print the position for good measure.