### PR TITLE
Updated MinExpiresMills to 100

### DIFF
--- a/src/NATS.Client/JetStream/BaseConsumeOptions.cs
+++ b/src/NATS.Client/JetStream/BaseConsumeOptions.cs
@@ -33,8 +33,8 @@ namespace NATS.Client.JetStream
         /// <summary>30_000</summary>
         public const int DefaultExpiresInMillis = 30000;
         
-        /// <summary>1000</summary>
-        public const int MinExpiresMills = 1000;
+        /// <summary>100</summary>
+        public const int MinExpiresMills = 100;
         
         /// <summary>30_000</summary>
         public const int MaxHearbeatMillis = 30000;


### PR DESCRIPTION
**MinExpiresMills** is the least possible time to wait value for fetch and consume, and currently it is set to 1 second. It would be great if either the allowed value is lower than the current value or if positive integer is acceptable.