### PR TITLE
KV Atomic Delete and Purge

### DIFF
--- a/src/NATS.Client/KeyValue/IKeyValue.cs
+++ b/src/NATS.Client/KeyValue/IKeyValue.cs
@@ -88,10 +88,24 @@ namespace NATS.Client.KeyValue
         void Delete(string key);
 
         /// <summary>
+        /// Soft deletes the key by placing a delete marker iff the key exists and its last revision matches the expected.
+        /// </summary>
+        /// <param name="key">the key</param>
+        /// <param name="expectedRevision">the expected last revision</param>
+        void Delete(string key, ulong expectedRevision);
+        
+        /// <summary>
         /// Purge all values/history from the specific key. 
         /// </summary>
         /// <param name="key">the key</param>
         void Purge(string key);
+        
+        /// <summary>
+        /// Purge all values/history from the specific key iff the key exists and its last revision matches the expected. 
+        /// </summary>
+        /// <param name="key">the key</param>
+        /// <param name="expectedRevision">the expected last revision</param>
+        void Purge(string key, ulong expectedRevision);
 
         /// <summary>
         /// Watch updates for a specific key

--- a/src/NATS.Client/KeyValue/KeyValue.cs
+++ b/src/NATS.Client/KeyValue/KeyValue.cs
@@ -145,9 +145,33 @@ namespace NATS.Client.KeyValue
             return _write(key, value, h).Seq;
         }
 
-        public void Delete(string key) => _write(key, null, DeleteHeaders);
+        public void Delete(string key)
+        {
+            Validator.ValidateKvKeyWildcardAllowedRequired(key);
+            _write(key, null, DeleteHeaders);
+        }
+        
+        public void Delete(string key, ulong expectedRevision)
+        {
+            Validator.ValidateKvKeyWildcardAllowedRequired(key);
+            MsgHeader h = DeleteHeaders;
+            h[JetStreamConstants.ExpLastSubjectSeqHeader] = expectedRevision.ToString();
+            _write(key, null, h);
+        }
 
-        public void Purge(string key) => _write(key, null, PurgeHeaders);
+        public void Purge(string key)        
+        {
+            Validator.ValidateKvKeyWildcardAllowedRequired(key);
+            _write(key, null, PurgeHeaders);
+        }
+        
+        public void Purge(string key, ulong expectedRevision)
+        {
+            Validator.ValidateKvKeyWildcardAllowedRequired(key);
+            MsgHeader h = PurgeHeaders;
+            h[JetStreamConstants.ExpLastSubjectSeqHeader] = expectedRevision.ToString();
+            _write(key, null, h);
+        }
         
         public KeyValueWatchSubscription Watch(string key, IKeyValueWatcher watcher, params KeyValueWatchOption[] watchOptions)
         {


### PR DESCRIPTION
https://github.com/nats-io/nats-architecture-and-design/issues/271
https://github.com/nats-io/nats.java/issues/1091

#### What's in this patch?

1. New public methods in IKeyValue for delete and purge with optimistic concurrency support:
```
void Delete(String key, ulong expectedRevision);
void Purge(String key, ulong expectedRevision);
```

2. New unit test `TestAtomicDeletePurge` with positive and negative cases.
