### PR TITLE
Change connection task error handling.

### DIFF
--- a/src/NATS.Client/Connection.cs
+++ b/src/NATS.Client/Connection.cs
@@ -400,16 +400,14 @@ namespace NATS.Client
                     {
                         nce = new NATSConnectionException(e.Message);
                     }
-                    finally
+
+                    if (nce != null)
                     {
-                        if (nce != null)
-                        {
-                            close(client);
-                            client = null;
-                            throw nce;
-                        }
+                        close(client);
+                        client = null;
+                        throw nce;
                     }
-                    
+
                     client.NoDelay = false;
 
                     client.ReceiveBufferSize = defaultBufSize * 2;

--- a/src/NATS.Client/Connection.cs
+++ b/src/NATS.Client/Connection.cs
@@ -364,7 +364,6 @@ namespace NATS.Client
 
             string hostName = null;
 
-            private int round = 0;
             public virtual void open(Srv s, Options options)
             {
                 this.options = options;
@@ -384,8 +383,6 @@ namespace NATS.Client
                         sslStream = null;
                     }
 
-                    ++round;
-                    Console.WriteLine("open start R:" + round + " " + s.Url);
                     client = new TcpClient(Socket.OSSupportsIPv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork);
                     if (Socket.OSSupportsIPv6)
                         client.Client.DualMode = true;
@@ -842,7 +839,6 @@ namespace NATS.Client
             pickServer();
         }
 
-        private int cc = 0;
         // createConn will connect to the server and wrap the appropriate
         // bufio structures. It will do the right thing when an existing
         // connection is in place.
@@ -851,8 +847,6 @@ namespace NATS.Client
             ex = null;
             try
             {
-                ++cc;
-                Console.WriteLine("CC:" + cc);
                 conn.open(s, opts);
 
                 if (pending != null && bw != null)
@@ -872,8 +866,6 @@ namespace NATS.Client
             }
             catch (Exception e)
             {
-                Console.WriteLine("CC EX:" + cc);
-                // Console.WriteLine("CC EX:" + cc + " | " + e);
                 ex = e;
                 return false;
             }

--- a/src/Samples/JetStreamStarter/JetStreamStarter.cs
+++ b/src/Samples/JetStreamStarter/JetStreamStarter.cs
@@ -22,7 +22,7 @@ namespace NATSExamples
 {
     internal static class JetStreamStarter
     {
-        static void Mainx(string[] args)
+        static void Main(string[] args)
         {
             Options opts = ConnectionFactory.GetDefaultOptions();
             
@@ -46,7 +46,7 @@ namespace NATSExamples
                 Console.WriteLine("Connection closed.");
             };
             
-            Console.WriteLine($"Connecting to '{opts.Servers[0]}'");
+            Console.WriteLine($"Connecting to '{opts.Url}'");
 
             using (IConnection c = new ConnectionFactory().CreateConnection(opts))
             {

--- a/src/Samples/JetStreamStarter/JetStreamStarter.cs
+++ b/src/Samples/JetStreamStarter/JetStreamStarter.cs
@@ -1,52 +1,43 @@
-﻿// Copyright 2022 The NATS Authors
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-using System;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
+﻿using System;
+using System.Threading;
 using NATS.Client;
 using NATS.Client.Internals;
+using NATS.Client.JetStream;
+using NATS.Client.KeyValue;
 
 namespace NATSExamples
 {
     internal static class JetStreamStarter
     {
-        static void Main(string[] args)
+        static void Mainx(string[] args)
         {
-            Options opts = Dbg.GetDefaultOptions();
-            // opts.Timeout = 5000;
-            opts.Servers = new [] {"tls://localhost:9222", "tls://localhost:4222"};
-            // opts.Servers = new [] {"tls://localhost:4222", "tls://localhost:9222"};
-            opts.NoRandomize = true;
-            opts.TlsFirst = true;
-            opts.Secure = true;
-            opts.TLSRemoteCertificationValidationCallback = (sender, certificate, chain, errors) =>
+            Options opts = ConnectionFactory.GetDefaultOptions();
+            
+            opts.Name = "the-client";
+            opts.Url = "nats://localhost:4222";
+            
+            opts.AsyncErrorEventHandler = (obj, a) =>
             {
-                Dbg.dbg("TLSRemoteCertificationValidationCallback");
-                return true;
+                Console.WriteLine($"Error: {a.Error}");
             };
+            opts.ReconnectedEventHandler = (obj, a) =>
+            {
+                Console.WriteLine($"Reconnected to {a.Conn.ConnectedUrl}");
+            };
+            opts.DisconnectedEventHandler = (obj, a) =>
+            {
+                Console.WriteLine("Disconnected.");
+            };
+            opts.ClosedEventHandler = (obj, a) =>
+            {
+                Console.WriteLine("Connection closed.");
+            };
+            
+            Console.WriteLine($"Connecting to '{opts.Servers[0]}'");
 
-            try
+            using (IConnection c = new ConnectionFactory().CreateConnection(opts))
             {
-                Dbg.dbg("B4");
-                using (IConnection c = new ConnectionFactory().CreateConnection(opts, true))
-                {
-                    Dbg.dbg("ServerInfo", c.ServerInfo);
-                }
-            }
-            catch (Exception e)
-            {
-                Dbg.dbg("EX", e);
+                Console.WriteLine("Connected.");
             }
         }
     }

--- a/src/Samples/JetStreamStarter/JetStreamStarter.cs
+++ b/src/Samples/JetStreamStarter/JetStreamStarter.cs
@@ -12,6 +12,8 @@
 // limitations under the License.
 
 using System;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using NATS.Client;
 using NATS.Client.Internals;
 
@@ -21,33 +23,30 @@ namespace NATSExamples
     {
         static void Main(string[] args)
         {
-            Options opts = ConnectionFactory.GetDefaultOptions();
-            
-            opts.Name = "the-client";
-            opts.Url = "nats://localhost:4222";
-            
-            opts.AsyncErrorEventHandler = (obj, a) =>
+            Options opts = Dbg.GetDefaultOptions();
+            // opts.Timeout = 5000;
+            opts.Servers = new [] {"tls://localhost:9222", "tls://localhost:4222"};
+            // opts.Servers = new [] {"tls://localhost:4222", "tls://localhost:9222"};
+            opts.NoRandomize = true;
+            opts.TlsFirst = true;
+            opts.Secure = true;
+            opts.TLSRemoteCertificationValidationCallback = (sender, certificate, chain, errors) =>
             {
-                Console.WriteLine($"Error: {a.Error}");
+                Dbg.dbg("TLSRemoteCertificationValidationCallback");
+                return true;
             };
-            opts.ReconnectedEventHandler = (obj, a) =>
-            {
-                Console.WriteLine($"Reconnected to {a.Conn.ConnectedUrl}");
-            };
-            opts.DisconnectedEventHandler = (obj, a) =>
-            {
-                Console.WriteLine("Disconnected.");
-            };
-            opts.ClosedEventHandler = (obj, a) =>
-            {
-                Console.WriteLine("Connection closed.");
-            };
-           
-            Console.WriteLine($"Connecting to '{opts.Url}'");
 
-            using (IConnection c = new ConnectionFactory().CreateConnection(opts))
+            try
             {
-                Console.WriteLine("Connected.");
+                Dbg.dbg("B4");
+                using (IConnection c = new ConnectionFactory().CreateConnection(opts, true))
+                {
+                    Dbg.dbg("ServerInfo", c.ServerInfo);
+                }
+            }
+            catch (Exception e)
+            {
+                Dbg.dbg("EX", e);
             }
         }
     }

--- a/src/Samples/JetStreamStarter/JetStreamStarter.cs
+++ b/src/Samples/JetStreamStarter/JetStreamStarter.cs
@@ -53,21 +53,5 @@ namespace NATSExamples
                 Console.WriteLine("Connected.");
             }
         }
-
-        private static void Reproduce(Options opts)
-        {
-            try
-            {
-                Dbg.dbg("B4");
-                using (IConnection c = new ConnectionFactory().CreateConnection(opts, true))
-                {
-                    Dbg.dbg("ServerInfo", c.ServerInfo);
-                }
-            }
-            catch (Exception e)
-            {
-                Dbg.dbg("EX", e);
-            }
-        }
     }
 }

--- a/src/Samples/JetStreamStarter/JetStreamStarter.cs
+++ b/src/Samples/JetStreamStarter/JetStreamStarter.cs
@@ -20,7 +20,7 @@ using NATS.Client.KeyValue;
 
 namespace NATSExamples
 {
-    internal static class JetStreamStarterDefault
+    internal static class JetStreamStarter
     {
         static void Mainx(string[] args)
         {

--- a/src/Samples/JetStreamStarter/JetStreamStarter.cs
+++ b/src/Samples/JetStreamStarter/JetStreamStarter.cs
@@ -53,5 +53,21 @@ namespace NATSExamples
                 Console.WriteLine("Connected.");
             }
         }
+
+        private static void Reproduce(Options opts)
+        {
+            try
+            {
+                Dbg.dbg("B4");
+                using (IConnection c = new ConnectionFactory().CreateConnection(opts, true))
+                {
+                    Dbg.dbg("ServerInfo", c.ServerInfo);
+                }
+            }
+            catch (Exception e)
+            {
+                Dbg.dbg("EX", e);
+            }
+        }
     }
 }

--- a/src/Samples/JetStreamStarter/JetStreamStarter.cs
+++ b/src/Samples/JetStreamStarter/JetStreamStarter.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Threading;
 using NATS.Client;
 using NATS.Client.Internals;
@@ -7,7 +20,7 @@ using NATS.Client.KeyValue;
 
 namespace NATSExamples
 {
-    internal static class JetStreamStarter
+    internal static class JetStreamStarterDefault
     {
         static void Mainx(string[] args)
         {


### PR DESCRIPTION
### Analysis
When a TLS connection fails, in this case the server being connected to is not even on-line, the next connection attempt sometimes freezes. It was intermittent, but reproducible. See code at end.

With some debugging, I could see where it was freezing, but it looked like it was inside the .net library code. What I noticed is that the connect code seemed overly complicated to me, and there was this `GC.KeepAlive(t.Exception);`. At the end of the day, we don't care why it failed, we just want to move on. So I simplified the code.

There was a corresponding TLS Handshake error in the server log.
```
[114772] 2024/03/06 15:16:37.763950 [DBG] [::1]:64363 - cid:20 - Starting TLS client connection handshake
[114772] 2024/03/06 15:16:37.763950 [ERR] [::1]:64363 - cid:20 - TLS handshake error: read tcp [::1]:4222->[::1]:64363: wsarecv: An established connection was aborted by the software in your host machine.
[114772] 2024/03/06 15:16:37.764607 [DBG] [::1]:64363 - cid:20 - Client connection closed: TLS Handshake Failure
``` 

Since this change, I cannot reproduce the problem and the error is not appearing in the server log.

### Code To Reproduce
```
static void Main(string[] args)
{
    Options opts = ConnectionFactory.GetDefaultOptions();
    opts.Servers = new [] {"tls://localhost:9222", "tls://localhost:4222"};
    opts.NoRandomize = true;
    opts.TlsFirst = true;
    opts.Secure = true;
    opts.TLSRemoteCertificationValidationCallback = (sndr, cert, chain, errs) => true;

    int round = 0;
    while (true)
    {
        Console.WriteLine($"Start Round {++round}");
        try
        {
            using (IConnection c = new ConnectionFactory().CreateConnection(opts, true))
            {
                Console.WriteLine("ServerInfo:" + c.ServerInfo);
            }
        }
        catch (Exception e)
        {
            Console.WriteLine(e.Message);
        }
        Console.WriteLine();
        Thread.Sleep(100);
    }
}
```