### PR TITLE
Messages not added to the channel don't count as pending for client side slow consumer purposes

### DIFF
--- a/src/NATS.Client/Subscription.cs
+++ b/src/NATS.Client/Subscription.cs
@@ -213,22 +213,22 @@ namespace NATS.Client
         // to the channel.
         internal bool addMessage(Msg msg)
         {
-            // Subscription internal stats
-	        pendingMessages++;
-	        if (pendingMessages > pendingMessagesMax)
-            {
-		        pendingMessagesMax = pendingMessages;
-            }
-	
-	        pendingBytes += msg.Data.Length;
-	        if (pendingBytes > pendingBytesMax)
-            {
-		        pendingBytesMax = pendingBytes;
-            }
-	
             // BeforeChannelAddCheck returns true if the message is allowed to be queued
             if (BeforeChannelAddCheck.Invoke(msg))
             {
+                // Subscription internal stats
+                pendingMessages++;
+                if (pendingMessages > pendingMessagesMax)
+                {
+                    pendingMessagesMax = pendingMessages;
+                }
+	
+                pendingBytes += msg.Data.Length;
+                if (pendingBytes > pendingBytesMax)
+                {
+                    pendingBytesMax = pendingBytes;
+                }
+
                 // Check for a Slow Consumer
                 if ((pendingMessagesLimit > 0 && pendingMessages > pendingMessagesLimit)
                     || (pendingBytesLimit > 0 && pendingBytes > pendingBytesLimit))


### PR DESCRIPTION
In response to https://github.com/nats-io/nats.net/issues/880