### PR TITLE
Fix line reader to resolve buffer issues on TLS connections

### DIFF
--- a/src/NATS.Client/Connection.cs
+++ b/src/NATS.Client/Connection.cs
@@ -5324,7 +5324,7 @@ namespace NATS.Client
         /// </summary>
         internal static string ReadUntilNewline(this Stream stream)
         {
-            const int maxAllowedSize = MaxControlLineSize * 1024;
+            const int maxAllowedSize = MaxControlLineSize * 16;
             var buffer = new byte[MaxControlLineSize];
             int byteValue;
             bool foundCR = false;

--- a/src/NATS.Client/Connection.cs
+++ b/src/NATS.Client/Connection.cs
@@ -1478,28 +1478,19 @@ namespace NATS.Client
             }
 
             string result = null;
-            StreamReader sr = null;
             try
             {
-                // TODO:  Make this reader (or future equivalent) unbounded.
-                // we need the underlying stream, so leave it open.
-                sr = new StreamReader(br, Encoding.UTF8, false, MaxControlLineSize, true);
-                result = sr.ReadLine();
+                result = br.ReadUntilNewline();
 
                 // If opts.verbose is set, handle +OK.
                 if (opts.Verbose && IC.okProtoNoCRLF.Equals(result))
                 {
-                    result = sr.ReadLine();
+                    result = br.ReadUntilNewline();
                 }
             }
             catch (Exception ex)
             {
                 throw new NATSConnectionException("Connect read error", ex);
-            }
-            finally
-            {
-                if (sr != null)
-                    sr.Dispose();
             }
 
             if (IC.pongProtoNoCRLF.Equals(result))
@@ -1527,16 +1518,7 @@ namespace NATS.Client
 
         private Control readOp()
         {
-            // This is only used when creating a connection, so simplify
-            // life and just create a stream reader to read the incoming
-            // info string.  If this becomes part of the fastpath, read
-            // the string directly using the buffered reader.
-            //
-            // Keep the underlying stream open.
-            using (StreamReader sr = new StreamReader(br, Encoding.ASCII, false, MaxControlLineSize, true))
-            {
-                return new Control(sr.ReadLine());
-            }
+            return new Control(br.ReadUntilNewline());
         }
 
         private void processDisconnect()
@@ -5327,4 +5309,53 @@ namespace NATS.Client
 
         #endregion
     } // class Conn
+    
+    internal static class StreamExtensions
+    {
+        /// <summary>
+        /// Consumes the stream one byte at a time until a newline is found.
+        /// This approach is used to avoid over-reading or under-reading the stream,
+        /// as it will be accessed in the reader loop as well.
+        /// Using StreamReader instead of this method can cause issues when a line
+        /// is delivered in chunks, especially over global connections, which is more
+        /// likely to occur.
+        /// The performance of this reading approach is relatively low, so it should only
+        /// be used in scenarios with low traffic, such as reading the server INFO.
+        /// </summary>
+        internal static string ReadUntilNewline(this Stream stream)
+        {
+            StringBuilder sb = new StringBuilder();
+            int byteValue;
+            bool foundCR = false;
+            var read = 0;
+
+            while ((byteValue = stream.ReadByte()) != -1)
+            {
+                if (++read > MaxControlLineSize)
+                {
+                    throw new NATSProtocolException("Control line maximum size exceeded.");
+                }
+                
+                if (byteValue == '\r')
+                {
+                    foundCR = true;
+                }
+                else if (byteValue == '\n' && foundCR)
+                {
+                    break;
+                }
+                else
+                {
+                    if (foundCR)
+                    {
+                        sb.Append('\r');
+                        foundCR = false;
+                    }
+                    sb.Append((char)byteValue);
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
 }

--- a/src/NATS.Client/Connection.cs
+++ b/src/NATS.Client/Connection.cs
@@ -5324,8 +5324,8 @@ namespace NATS.Client
         /// </summary>
         internal static string ReadUntilNewline(this Stream stream)
         {
+            const int maxAllowedSize = MaxControlLineSize * 1024;
             var buffer = new byte[MaxControlLineSize];
-            var maxAllowedSize = MaxControlLineSize * 1024;
             int byteValue;
             bool foundCR = false;
             var read = 0;

--- a/src/NATS.Client/Connection.cs
+++ b/src/NATS.Client/Connection.cs
@@ -5343,7 +5343,7 @@ namespace NATS.Client
                 {
                     if (foundCR)
                     {
-                        buffer[read - 2] = (byte)'\r';
+                        buffer[read - 1] = (byte)'\r';
                         foundCR = false;
                     }
                     buffer[read] = (byte)byteValue;

--- a/src/NATS.Client/Connection.cs
+++ b/src/NATS.Client/Connection.cs
@@ -5367,7 +5367,7 @@ namespace NATS.Client
                 throw new NATSProtocolException("Control line does not end with CRLF.");
             }
             
-            return Encoding.UTF8.GetString(buffer, 0, read - 1);
+            return Encoding.UTF8.GetString(buffer, 0, read);
         }
     }
 }


### PR DESCRIPTION
The StreamReader usage when reading the server INFO causes buffer issues on the stream, as it is also read in the reader loop. The StreamReader might consume or return the read bytes back, leading to problems when used on a TLS connection with .NET versions lower than 8. This fix removes the StreamReader usage to address these issues.

fixes https://github.com/nats-io/nats.net/issues/586#issuecomment-2076701242