### PR TITLE
Netstandard 2 build changes

### DIFF
--- a/az-templates/stage-build.yml
+++ b/az-templates/stage-build.yml
@@ -22,7 +22,7 @@ stages:
       displayName: 'UnitTests Net Standard 2.0'
       inputs:
         testSelector: 'testAssemblies'
-        testAssemblyVer2: 'src/Tests/UnitTests/bin/$(BuildConfiguration)/netstandard2.0/UnitTests.dll'
+        testAssemblyVer2: 'src/Tests/UnitTests/bin/$(BuildConfiguration)/net462/UnitTests.dll'
         configuration: $(BuildConfiguration)
         testRunTitle: 'UnitTests Net Standard 2.0'
   
@@ -44,7 +44,7 @@ stages:
         GODEBUG: x509sha1=1
       inputs:
         testSelector: 'testAssemblies'
-        testAssemblyVer2: 'src/Tests/IntegrationTests/bin/$(BuildConfiguration)/netstandard2.0/IntegrationTests.dll'
+        testAssemblyVer2: 'src/Tests/IntegrationTests/bin/$(BuildConfiguration)/net462/IntegrationTests.dll'
         configuration: $(BuildConfiguration)
         rerunFailedTests: True
         rerunMaxAttempts: 2
@@ -56,7 +56,7 @@ stages:
         GODEBUG: x509sha1=1
       inputs:
         testSelector: 'testAssemblies'
-        testAssemblyVer2: 'src/Tests/IntegrationTestsInternal/bin/$(BuildConfiguration)/netstandard2.0/IntegrationTestsInternal.dll'
+        testAssemblyVer2: 'src/Tests/IntegrationTestsInternal/bin/$(BuildConfiguration)/net462/IntegrationTestsInternal.dll'
         configuration: $(BuildConfiguration)
         rerunFailedTests: True
         rerunMaxAttempts: 2

--- a/az-templates/stage-build.yml
+++ b/az-templates/stage-build.yml
@@ -18,21 +18,13 @@ stages:
         projects: 'src/*.sln'
         arguments: '-c $(BuildConfiguration) --no-incremental --nologo -p:TreatWarningsAsErrors=true -p:Version=$(SemVer) -p:InformationalVersion=$(InfoVer)'
   
-#    - task: VSTest@2
-#      displayName: 'UnitTests .NetCoreApp3.1'
-#      inputs:
-#        testSelector: 'testAssemblies'
-#        testAssemblyVer2: 'src/Tests/UnitTests/bin/$(BuildConfiguration)/netcoreapp3.1/UnitTests.dll'
-#        configuration: $(BuildConfiguration)
-#        testRunTitle: 'UnitTests .NetCoreApp3.1'
-  
     - task: VSTest@2
-      displayName: 'UnitTests .Net4.6'
+      displayName: 'UnitTests Net Standard 2.0'
       inputs:
         testSelector: 'testAssemblies'
-        testAssemblyVer2: 'src/Tests/UnitTests/bin/$(BuildConfiguration)/net46/UnitTests.dll'
+        testAssemblyVer2: 'src/Tests/UnitTests/bin/$(BuildConfiguration)/netstandard2.0/UnitTests.dll'
         configuration: $(BuildConfiguration)
-        testRunTitle: 'UnitTests .Net4.6'
+        testRunTitle: 'UnitTests Net Standard 2.0'
   
     - task: PowerShell@2
       displayName: 'Install Dependencies'
@@ -46,63 +38,29 @@ stages:
           Write-Host "Appending nats-server directory $nats to path."
           Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};$nats"
 
-#    - task: VSTest@2
-#      displayName: 'IntegrationTests .NetCoreApp3.1'
-#      env:
-#        GODEBUG: x509sha1=1
-#      inputs:
-#        testSelector: 'testAssemblies'
-#        testAssemblyVer2: 'src/Tests/IntegrationTests/bin/$(BuildConfiguration)/netcoreapp3.1/IntegrationTests.dll'
-#        configuration: $(BuildConfiguration)
-#        rerunFailedTests: True
-#        rerunMaxAttempts: 2
-#        testRunTitle: 'IntegrationTests .NetCoreApp3.1'
-
     - task: VSTest@2
-      displayName: 'IntegrationTests .Net4.6'
+      displayName: 'IntegrationTests Net Standard 2.0'
       env:
         GODEBUG: x509sha1=1
       inputs:
         testSelector: 'testAssemblies'
-        testAssemblyVer2: 'src/Tests/IntegrationTests/bin/$(BuildConfiguration)/net46/IntegrationTests.dll'
+        testAssemblyVer2: 'src/Tests/IntegrationTests/bin/$(BuildConfiguration)/netstandard2.0/IntegrationTests.dll'
         configuration: $(BuildConfiguration)
         rerunFailedTests: True
         rerunMaxAttempts: 2
-        testRunTitle: 'IntegrationTests .Net4.6'
-
-#    - task: VSTest@2
-#      displayName: 'IntegrationTests Internal .NetCoreApp3.1'
-#      env:
-#        GODEBUG: x509sha1=1
-#      inputs:
-#        testSelector: 'testAssemblies'
-#        testAssemblyVer2: 'src/Tests/IntegrationTestsInternal/bin/$(BuildConfiguration)/netcoreapp3.1/IntegrationTestsInternal.dll'
-#        configuration: $(BuildConfiguration)
-#        rerunFailedTests: True
-#        rerunMaxAttempts: 2
-#        testRunTitle: 'IntegrationTests Internal .NetCoreApp3.1'
+        testRunTitle: 'IntegrationTests Net Standard 2.0'
 
     - task: VSTest@2
-      displayName: 'IntegrationTests Internal .Net4.6'
+      displayName: 'IntegrationTests Internal Net Standard 2.0'
       env:
         GODEBUG: x509sha1=1
       inputs:
         testSelector: 'testAssemblies'
-        testAssemblyVer2: 'src/Tests/IntegrationTestsInternal/bin/$(BuildConfiguration)/net46/IntegrationTestsInternal.dll'
+        testAssemblyVer2: 'src/Tests/IntegrationTestsInternal/bin/$(BuildConfiguration)/netstandard2.0/IntegrationTestsInternal.dll'
         configuration: $(BuildConfiguration)
         rerunFailedTests: True
         rerunMaxAttempts: 2
-        testRunTitle: 'IntegrationTests Internal .Net4.6'
-
-#    - task: VSTest@2
-#      displayName: 'IntegrationTests Using Nito AsyncEx .NetCoreApp3.1'
-#      inputs:
-#        testSelector: 'testAssemblies'
-#        testAssemblyVer2: 'src/Tests/IntegrationTestsUsingNitoAsyncEx/bin/$(BuildConfiguration)/netcoreapp3.1/IntegrationTestsUsingNitoAsyncEx.dll'
-#        configuration: $(BuildConfiguration)
-#        rerunFailedTests: True
-#        rerunMaxAttempts: 2
-#        testRunTitle: 'IntegrationTests Using Nito AsyncEx .NetCoreApp3.1'
+        testRunTitle: 'IntegrationTests Internal Net Standard 2.0'
         
     - task: DotNetCoreCLI@2
       displayName: 'Pack Nupkg'

--- a/az-templates/stage-build.yml
+++ b/az-templates/stage-build.yml
@@ -6,10 +6,6 @@ stages:
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
     steps:
-    - task: UseDotNet@2
-      displayName: 'Install .NET Core SDK'
-      inputs:
-        version: 8.x
     - task: NugetToolInstaller@1
     - task: DotNetCoreCLI@2
       inputs:

--- a/az-templates/stage-build.yml
+++ b/az-templates/stage-build.yml
@@ -6,6 +6,10 @@ stages:
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
     steps:
+    - task: UseDotNet@2
+      displayName: 'Install .NET Core SDK'
+      inputs:
+        version: 8.x
     - task: NugetToolInstaller@1
     - task: DotNetCoreCLI@2
       inputs:

--- a/src/Benchmarks/MicroBenchmarks/MicroBenchmarks.csproj
+++ b/src/Benchmarks/MicroBenchmarks/MicroBenchmarks.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFramework>net462</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netcoreapp3.1;net46</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.0.0</Version>
     <Company>CNCF</Company>
     <Authors>The NATS Authors</Authors>

--- a/src/NATS.Client/NATS.Client.csproj
+++ b/src/NATS.Client/NATS.Client.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netstandard1.6;netstandard2.0;net46</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Title>NATS .NET Client</Title>
     <Description>**NOTE** For .NET 6 upwards we recommend NATS.Net package - NATS acts as a central nervous system for distributed systems at scale for IoT, edge computing, and cloud native and on-premise applications.  This is the .NET client API.</Description>
     <PackageId>NATS.Client</PackageId>

--- a/src/Samples/JetStreamExampleUtils/JetStreamExampleUtils.csproj
+++ b/src/Samples/JetStreamExampleUtils/JetStreamExampleUtils.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net462;net6.0</TargetFrameworks>
         <Title>NATS JetStream Example Utils</Title>
         <PackageId>NATS.JetStreamExampleUtils</PackageId>
         <Description>NATS JetStream Example Utils Library</Description>
@@ -9,13 +8,6 @@
         <DebugSymbols>true</DebugSymbols>
         <RootNamespace>NATSExamples</RootNamespace>
     </PropertyGroup>
-
-    <ItemGroup Condition="$(TargetFramework) == 'netstandard1.6'">
-        <PackageReference Include="System.Net.Security" Version="4.3.2" />
-        <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
-        <PackageReference Include="System.Runtime" Version="4.3.1" />
-        <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />

--- a/src/Samples/JetStreamExampleUtils/JetStreamExampleUtils.csproj
+++ b/src/Samples/JetStreamExampleUtils/JetStreamExampleUtils.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks Condition="$(OS) == 'Windows_NT'">netstandard1.6;net46</TargetFrameworks>
-        <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1;netstandard1.6</TargetFrameworks>
+        <TargetFrameworks>net462;net6.0</TargetFrameworks>
         <Title>NATS JetStream Example Utils</Title>
         <PackageId>NATS.JetStreamExampleUtils</PackageId>
         <Description>NATS JetStream Example Utils Library</Description>

--- a/src/Samples/WinFormsSample/Program.cs
+++ b/src/Samples/WinFormsSample/Program.cs
@@ -11,7 +11,6 @@ namespace WinFormsSample
         [STAThread]
         static void Main()
         {
-            Application.SetHighDpiMode(HighDpiMode.SystemAware);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new Form1());

--- a/src/Samples/WinFormsSample/WinFormsSample.csproj
+++ b/src/Samples/WinFormsSample/WinFormsSample.csproj
@@ -9,7 +9,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="$(OS) == 'Windows_NT'" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net462</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Tests/IntegrationTests/IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/IntegrationTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Tests/IntegrationTestsInternal/IntegrationTestsInternal.csproj
+++ b/src/Tests/IntegrationTestsInternal/IntegrationTestsInternal.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net462</TargetFramework>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/src/Tests/IntegrationTestsUsingNitoAsyncEx/IntegrationTestsUsingNitoAsyncEx.csproj
+++ b/src/Tests/IntegrationTestsUsingNitoAsyncEx/IntegrationTestsUsingNitoAsyncEx.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net462</TargetFramework>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
@@ -14,7 +15,7 @@
         </PackageReference>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <ItemGroup>
         <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
     </ItemGroup>
 

--- a/src/Tests/UnitTests/UnitTests.csproj
+++ b/src/Tests/UnitTests/UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
We are removing support for `netstandard1.6` and `net46` targets and will only support the `netstandard2.0` target. This change is intended to simplify maintenance. As a result, some platforms will no longer be supported. For more information, please refer to the compatibility table provided by Microsoft: [Select .NET Standard version](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#select-net-standard-version).