### PR TITLE
KV TTL (stream max_age) versus stream duplicate_window

### DIFF
--- a/src/NATS.Client/Internals/JetStreamConstants.cs
+++ b/src/NATS.Client/Internals/JetStreamConstants.cs
@@ -15,6 +15,8 @@ namespace NATS.Client.Internals
         /// </summary>
         public const int MaxHistoryPerKey = 64;
 
+        public const long ServerDefaultDuplicateWindowMs = 120_000; // 1000ms/sec * 60sec/min * 2 min
+
         /// <summary>
         /// The standard JetStream Prefix prefix 
         /// </summary>


### PR DESCRIPTION
Ensure that duplicate window is
* never more than 2 minutes
* never greater than the max_age