### PR TITLE
NuGet note to deprecate the package

### DIFF
--- a/src/NATS.Client/NATS.Client.csproj
+++ b/src/NATS.Client/NATS.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Title>NATS .NET Client</Title>
-    <Description>**NOTE** For .NET 6 upwards we recommend NATS.Net package - NATS acts as a central nervous system for distributed systems at scale for IoT, edge computing, and cloud native and on-premise applications.  This is the .NET client API.</Description>
+    <Description>Use NATS.Net instead. We will deprecate this package eventually.</Description>
     <PackageId>NATS.Client</PackageId>
     <PackageProjectUrl>https://nats.io</PackageProjectUrl>
     <PackageIcon>package-icon.png</PackageIcon>


### PR DESCRIPTION
We had a few reports people still landing on this package by just using NuGet interfaces on Visual Studio. This note should help guide some of those new developers.

**note** if we don't want to say 'deprecated' we can say 'we suggest' or something to that effect if you like.

**note2** also the current text is not accurate since now v2 supports netstandard as well, so 'net6 and above' is not right