### PR TITLE
Fix header value validation

### DIFF
--- a/src/NATS.Client/MsgHeader.cs
+++ b/src/NATS.Client/MsgHeader.cs
@@ -117,11 +117,12 @@ namespace NATS.Client
             {
                 foreach (char c in value)
                 {
-                    // Generally more permissive than HTTP.  Allow only printable
-                    // characters and include tab (0x9) to cover what's allowed
-                    // in quoted strings and comments.
-                    if ((c < 32 && c != 9) || c > 126)
+                    // Like rfc822 section 3.1.2 (quoted in ADR 4)
+                    // The field-body may be composed of any US-ASCII characters, except CR or LF.
+                    if (c > 127 || c == 10 || c == 13)
+                    {
                         throw new ArgumentException(string.Format("Invalid character {0:X2} in value.", c));
+                    }
                 }
             }
         }

--- a/src/Tests/UnitTests/TestMessageHeaders.cs
+++ b/src/Tests/UnitTests/TestMessageHeaders.cs
@@ -303,8 +303,6 @@ namespace UnitTests
             Assert.Throws<ArgumentException>(() => mh["k\r\ney"] = "value");
             Assert.Throws<ArgumentException>(() => mh["key"] = "val\r\nue");
             Assert.Throws<ArgumentException>(() => mh["foo:bar"] = "value");
-            Assert.Throws<ArgumentException>(() => mh["foo"] = "value\f");
-            Assert.Throws<ArgumentException>(() => mh["foo\f"] = "value");
 
             // test constructor with invalid assignment
             Assert.Throws<ArgumentException>(() => new MsgHeader() { ["foo:bar"] = "baz" });

--- a/src/Tests/UnitTests/TestMessageHeaders.cs
+++ b/src/Tests/UnitTests/TestMessageHeaders.cs
@@ -66,6 +66,22 @@ namespace UnitTests
         }
 
         [Fact]
+        public void valueCharactersMustBeUSAsciiExceptForCRLF()
+        {
+            MsgHeader headers = new MsgHeader();
+            for (int c = 0; c < 256; c++) {
+                String val = "val" + (char)c;
+                if (c == 10 || c == 13 || c > 127) {
+                    Assert.Throws<ArgumentException>(() => { headers["key"] = val; });
+                }
+                else {
+                    headers["key"] = val;
+                    Assert.Equal(val, headers["key"]);
+                }
+            }
+        }
+
+        [Fact]
         public void TestHeaderDeserialization()
         {
             byte[] hb = Encoding.ASCII.GetBytes("NATS/1.0\r\nfoo:bar\r\nbaz:bam\r\n\r\n");


### PR DESCRIPTION
Like rfc822 section 3.1.2 (quoted in ADR 4)
The field-body may be composed of any US-ASCII characters, except CR or LF.