### PR TITLE
ObjectMeta metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,27 +1037,3 @@ Lat8k (us)	500 msgs, 363.56 avg, 131.50 min, 39428.50 max, 1990.81 stddev
 A note:  The NATS C# .NET client was originally developed with the idea in mind that it would support the .NET 4.0 code base for increased adoption, and closely parallel the GO client (internally) for maintenance purposes.  So, some of the nice .NET APIs/features were intentionally left out.  While this has certainly paid off, after consideration, and some maturation of the NATS C# library, the NATS C# code will move toward more idiomatic .NET coding style where it makes sense.
 
 To that end, with any contributions, certainly feel free to code in a more .NET idiomatic style than what you see.  PRs are always welcome!
-
-## TODO
-
-* [x] Key Value
-* [x] Ordered Consumer
-* [x] Object Store
-* [x] JetStream
-* [ ] Another performance pass - look at stream directly over socket, contention, fastpath optimizations, rw locks.
-* [ ] Rx API (unified over NATS Streaming?)
-* [ ] Allow configuration for performance tuning (buffer sizes), defaults based on plaform.
-* [ ] Azure Service Bus Connector
-* [ ] Visual Studio [Starter Kit](https://msdn.microsoft.com/en-us/library/ccd9ychb.aspx)
-* [x] Expand Unit Tests to test internals (namely Parsing)
-* [X] Travis CI (Used AppVeyor instead)
-* [X] [.NET Core](https://github.com/dotnet/core) compatibility, TLS required.
-* [X] Convert unit tests to xunit
-* [X] Comprehensive benchmarking
-* [X] TLS
-* [X] Encoding (Serialization/Deserialization)
-* [X] Update delegates from traditional model to custom
-* [X] NuGet package
-* [X] Strong name the assembly
-
-Any suggestions and/or contributions are welcome!

--- a/src/NATS.Client/ObjectStore/ObjectInfo.cs
+++ b/src/NATS.Client/ObjectStore/ObjectInfo.cs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 using NATS.Client.Internals;
 using NATS.Client.Internals.SimpleJSON;
@@ -36,6 +37,7 @@ namespace NATS.Client.ObjectStore
         public string ObjectName => ObjectMeta.ObjectName;
         public string Description => ObjectMeta.Description;
         public MsgHeader Headers => ObjectMeta.Headers;
+        public IDictionary<string, string> Metadata => ObjectMeta.Metadata;
         public bool IsLink => ObjectMeta.ObjectMetaOptions.Link != null;
         public ObjectLink Link => ObjectMeta.ObjectMetaOptions.Link; 
 

--- a/src/NATS.Client/ObjectStore/ObjectMeta.cs
+++ b/src/NATS.Client/ObjectStore/ObjectMeta.cs
@@ -80,7 +80,7 @@ namespace NATS.Client.ObjectStore
             return ObjectName == other.ObjectName 
                    && Description == other.Description 
                    && Equals(Headers, other.Headers) 
-                   && Equals(Metadata, other.Metadata) 
+                   && Validator.DictionariesEqual(Metadata, other.Metadata) 
                    && Equals(ObjectMetaOptions, other.ObjectMetaOptions);
         }
 

--- a/src/NATS.Client/ObjectStore/ObjectMeta.cs
+++ b/src/NATS.Client/ObjectStore/ObjectMeta.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 The NATS Authors
+﻿// Copyright 2022-2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
 using NATS.Client.Internals;
 using NATS.Client.Internals.SimpleJSON;
 using NATS.Client.JetStream;
@@ -25,6 +26,7 @@ namespace NATS.Client.ObjectStore
         public string ObjectName { get; }
         public string Description { get; }
         public MsgHeader Headers { get; }
+        public IDictionary<string, string> Metadata { get; }
         public ObjectMetaOptions ObjectMetaOptions { get; }
 
         internal ObjectMeta(JSONNode node)
@@ -32,6 +34,7 @@ namespace NATS.Client.ObjectStore
             ObjectName = node[ApiConstants.Name];
             Description = node[ApiConstants.Description];
             Headers = JsonUtils.AsHeaders(node, ApiConstants.Headers);
+            Metadata = JsonUtils.StringStringDictionary(node, ApiConstants.Metadata, false);
             JSONNode optNode = node[ApiConstants.Options];
             if (optNode == null)
             {
@@ -48,6 +51,7 @@ namespace NATS.Client.ObjectStore
             ObjectName = b._objectName;
             Description = b._description;
             Headers = b._headers;
+            Metadata = b._metadata;
             ObjectMetaOptions = b._metaOptionsBuilder.Build();
         }
 
@@ -63,6 +67,8 @@ namespace NATS.Client.ObjectStore
             jsonObject[ApiConstants.Name] = ObjectName;
             jsonObject[ApiConstants.Description] = Description;
             JsonUtils.AddField(jsonObject, ApiConstants.Headers, Headers);
+            JsonUtils.AddField(jsonObject, ApiConstants.Metadata, Metadata);
+
             if (ObjectMetaOptions.HasData)
             {
                 jsonObject[ApiConstants.Options] = ObjectMetaOptions.ToJsonNode();
@@ -74,6 +80,7 @@ namespace NATS.Client.ObjectStore
             return ObjectName == other.ObjectName 
                    && Description == other.Description 
                    && Equals(Headers, other.Headers) 
+                   && Equals(Metadata, other.Metadata) 
                    && Equals(ObjectMetaOptions, other.ObjectMetaOptions);
         }
 
@@ -92,6 +99,7 @@ namespace NATS.Client.ObjectStore
                 var hashCode = (ObjectName != null ? ObjectName.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (Description != null ? Description.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (Headers != null ? Headers.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Metadata != null ? Metadata.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (ObjectMetaOptions != null ? ObjectMetaOptions.GetHashCode() : 0);
                 return hashCode;
             }
@@ -113,11 +121,13 @@ namespace NATS.Client.ObjectStore
             internal string _objectName;
             internal string _description;
             internal MsgHeader _headers;
+            internal IDictionary<string, string> _metadata;
             internal ObjectMetaOptions.ObjectMetaOptionsBuilder _metaOptionsBuilder;
 
             public ObjectMetaBuilder(string objectName)
             {
                 _headers = new MsgHeader();
+                _metadata = new Dictionary<string, string>();
                 _metaOptionsBuilder = ObjectMetaOptions.Builder();
                 WithObjectName(objectName);
             }
@@ -126,6 +136,7 @@ namespace NATS.Client.ObjectStore
                 _objectName = om.ObjectName;
                 _description = om.Description;
                 _headers = om.Headers;
+                _metadata = new Dictionary<string, string>(om.Metadata);
                 _metaOptionsBuilder = ObjectMetaOptions.Builder(om.ObjectMetaOptions);
             }
 
@@ -147,6 +158,18 @@ namespace NATS.Client.ObjectStore
                 else
                 {
                     _headers = headers;
+                }
+                return this;
+            }
+
+            public ObjectMetaBuilder WithMetadata(IDictionary<string, string> metadata) {
+                if (metadata == null)
+                {
+                    _metadata.Clear();
+                }
+                else
+                {
+                    _metadata = metadata;
                 }
                 return this;
             }

--- a/src/Tests/UnitTests/Data/ObjectInfo.json
+++ b/src/Tests/UnitTests/Data/ObjectInfo.json
@@ -5,6 +5,10 @@
     "key-1": ["data-1"],
     "key-2": ["data-21", "data-22"]
   },
+  "metadata": {
+    "meta-key-1": "meta-data-1",
+    "meta-key-2": "meta-data-2"
+  },
   "options": {
     "link": {
       "bucket": "link-to-bucket",

--- a/src/Tests/UnitTests/JetStream/TestObjectStoreApi.cs
+++ b/src/Tests/UnitTests/JetStream/TestObjectStoreApi.cs
@@ -86,12 +86,20 @@ namespace UnitTests.JetStream
             Assert.Equal(modified, oi.Modified);
             Assert.Equal(2, oi.Headers.Count);
             IList<string> list = oi.Headers.GetValues(Key(1));
+            Assert.NotNull(list);
             Assert.Equal(1, list.Count);
             Assert.Equal(Data(1), oi.Headers[Key(1)]);
             list = oi.Headers.GetValues(Key(2));
+            Assert.NotNull(list);
             Assert.Equal(2, list.Count);
             Assert.True(list.Contains(Data(21)));
             Assert.True(list.Contains(Data(22)));
+            
+            IDictionary<string, string> meta = oi.Metadata;
+            Assert.NotNull(meta);
+            Assert.Equal(2, meta.Count);
+            Assert.Equal("meta-data-1", meta["meta-key-1"]);
+            Assert.Equal("meta-data-2", meta["meta-key-2"]);
         }
 
         [Fact]


### PR DESCRIPTION
The client has ObjectMeta Headers, which is a dictionary of string (key) to list of strings (value), but does not have the additional, almost identical field of metadata, which is a dictionary of string (key) to string (value).